### PR TITLE
[Feature/dashboard-api] 대시보드 API 연결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    domains: ['sprint-fe-project.s3.ap-northeast-2.amazonaws.com'],
+  },
 }
 
 module.exports = nextConfig

--- a/src/api/services/cardsServices.ts
+++ b/src/api/services/cardsServices.ts
@@ -1,5 +1,5 @@
 import type {
-  Card,
+  CardType,
   GetCardsResponse,
   CreateCardBody,
   UpdateCardBody,
@@ -10,7 +10,7 @@ import { useAuthStore } from '@/stores/auth'
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || ''
 
 // POST: 카드 생성
-const postCards = async (body: CreateCardBody): Promise<Card> => {
+const postCards = async (body: CreateCardBody): Promise<CardType> => {
   const accessToken = useAuthStore.getState().accessToken
 
   if (!accessToken) {
@@ -61,7 +61,7 @@ const getCards = async (
 const putCards = async (
   cardId: number,
   body: UpdateCardBody
-): Promise<Card> => {
+): Promise<CardType> => {
   const accessToken = useAuthStore.getState().accessToken
 
   if (!accessToken) {
@@ -82,7 +82,7 @@ const putCards = async (
 }
 
 // GET: 카드 상세 조회
-const getCardsDetail = async (cardId: number): Promise<Card> => {
+const getCardsDetail = async (cardId: number): Promise<CardType> => {
   const accessToken = useAuthStore.getState().accessToken
 
   if (!accessToken) {

--- a/src/api/services/columnsServices.ts
+++ b/src/api/services/columnsServices.ts
@@ -1,5 +1,5 @@
 import type {
-  Column,
+  ColumnType,
   CreateColumnBody,
   UpdateColumnBody,
   GetColumnsResponse,
@@ -11,7 +11,7 @@ import { useAuthStore } from '@/stores/auth'
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || ''
 
 // POST: 컬럼 생성
-const postColumns = async (body: CreateColumnBody): Promise<Column> => {
+const postColumns = async (body: CreateColumnBody): Promise<ColumnType> => {
   const accessToken = useAuthStore.getState().accessToken
 
   if (!accessToken) {
@@ -55,7 +55,7 @@ const getColumns = async (dashboardId: number): Promise<GetColumnsResponse> => {
 const putColumns = async (
   columnId: number,
   body: UpdateColumnBody
-): Promise<Column> => {
+): Promise<ColumnType> => {
   const accessToken = useAuthStore.getState().accessToken
 
   if (!accessToken) {

--- a/src/components/common/tag/Tag.tsx
+++ b/src/components/common/tag/Tag.tsx
@@ -1,14 +1,39 @@
+import Image from 'next/image'
 import styles from './Tag.module.css'
 import type { TagProps } from '@/types/common/tag'
 
-export default function Tag({ label, color }: TagProps) {
+interface ExtendedTagProps extends TagProps {
+  isDeletable?: boolean
+  onDelete?: () => void
+}
+
+export default function Tag({
+  label,
+  color,
+  isDeletable = false,
+  onDelete,
+}: ExtendedTagProps) {
   return (
     <div
       className={`${styles.tag} ${
         styles[color as keyof typeof styles]
-      } text-md-regular`}
+      } text-md-regular relative`}
     >
       {label}
+      {isDeletable && onDelete && (
+        <button
+          type="button"
+          onClick={onDelete}
+          className="ml-[0.2rem] flex items-center justify-center"
+        >
+          <Image
+            src="/assets/image/close.svg"
+            alt="태그 삭제"
+            width={12}
+            height={12}
+          />
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/domain/dashboard/Card.tsx
+++ b/src/components/domain/dashboard/Card.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Tag from '@/components/common/tag/Tag' // 개별 카드
 import { CardType } from '@/types/api/cards'
+import styles from './card.module.css'
 
 // 내부에서만 사용
 export interface CardProps {
@@ -9,22 +10,22 @@ export interface CardProps {
 
 export default function Card({ cardInfo }: CardProps) {
   return (
-    <div className="w-full rounded-md bg-white shadow-sm overflow-hidden">
+    <div className={styles.card}>
       {/* 이미지: 현재 props로 받은 imageUrl 사용,
       추후 카드 상세 모달에서 이미지 업로드 API 연동 예정 */}
       {cardInfo.imageUrl && (
-        <div className="pt-[1.6rem] px-[2rem]">
+        <div className={styles.imageWrapper}>
           <Image
             src={cardInfo.imageUrl}
             alt="카드 이미지"
-            className="w-full h-[16rem] object-cover"
+            className={styles.image}
             width={500}
             height={0}
           />
         </div>
       )}
 
-      <div className="pt-[1.6rem] pb-[1.6rem] px-[2rem] flex flex-col gap-2">
+      <div className={styles.content}>
         {/* 제목: 현재는 title props 그대로 사용,
         추후 모달에서 수정 가능한 입력 필드로 연동 예정 */}
         <h4 className="text-lg-medium" style={{ color: 'var(--black-333236)' }}>
@@ -33,30 +34,27 @@ export default function Card({ cardInfo }: CardProps) {
 
         {/* 태그 리스트: 랜덤 스타일 태그 사용 중,
         추후 모달에서 태그 추가/삭제 및 색상 재지정 연동 예정*/}
-        <div className="flex flex-wrap gap-[0.6rem]">
-          {cardInfo.tags.map((tag, idx) => (
-            <Tag key={idx} label={tag.label} color={tag.color} />
+        <div className={styles.tagList}>
+          {cardInfo.tags.map((tag, index) => (
+            <Tag key={index} label={tag.label} color={tag.color} />
           ))}
         </div>
 
-        <div
-          className="flex justify-between items-center text-xs-medium"
-          style={{ color: 'var(--gray-787486)' }}
-        >
-          <div className="flex items-center gap-1">
+        <div className={styles.meta}>
+          <div className={styles.dateSection}>
             <Image
               src="/assets/icon/calendar.svg"
               alt="달력 아이콘"
               width={18}
               height={18}
-              className="inline-block"
+              className={styles.calendarIcon}
             />
             {/* 날짜는 string으로 받은 값 (ex: '2025-12-31')이며,
             추후 카드 상세 모달에서 Date 객체로 변환하여 처리할 예정 */}
             <span>{cardInfo.dueDate}</span>
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className={styles.assigneeSection}>
             {/* 추후 assignee.profileImageUrl로 프로필 이미지 표시 예정
               현재는 nickname 텍스트만 출력 중 */}
             {/* assignee에 프로필 이미지가 추가 안된 상태여서 에러가 나는 상황 */}

--- a/src/components/domain/dashboard/Card.tsx
+++ b/src/components/domain/dashboard/Card.tsx
@@ -1,45 +1,10 @@
 import Image from 'next/image'
 import Tag from '@/components/common/tag/Tag' // 개별 카드
-
-// API의 경우, [GET] 카드 목록 조회 사용
-type TagColor =
-  | 'tag-orange'
-  | 'tag-pink'
-  | 'tag-blue'
-  | 'tag-green'
-  | 'tag-purple'
-  | 'tag-yellow'
-  | 'tag-red'
-  | 'tag-teal'
-  | 'tag-brown'
-  | 'tag-gray'
-
-// Tag.ts와 연동 필요
-export interface CardTag {
-  label: string
-  color: TagColor // 예: 'tag-orange'
-}
-
-// API 연동
-interface Assignee {
-  id: number
-  nickname: string
-  profileImageUrl: string
-}
-
-// API 연동
-export interface CardInfo {
-  id: number
-  title: string
-  tags: CardTag[]
-  dueDate: string
-  assignee: Assignee
-  imageUrl?: string
-}
+import { CardType } from '@/types/api/cards'
 
 // 내부에서만 사용
 export interface CardProps {
-  cardInfo: CardInfo
+  cardInfo: CardType
 }
 
 export default function Card({ cardInfo }: CardProps) {
@@ -94,13 +59,14 @@ export default function Card({ cardInfo }: CardProps) {
           <div className="flex items-center gap-2">
             {/* 추후 assignee.profileImageUrl로 프로필 이미지 표시 예정
               현재는 nickname 텍스트만 출력 중 */}
-            <Image
+            {/* assignee에 프로필 이미지가 추가 안된 상태여서 에러가 나는 상황 */}
+            {/* <Image
               src={cardInfo.assignee.profileImageUrl}
               alt="프로필 이미지"
               width={24}
               height={24}
               className="w-6 h-6 rounded-full object-cover"
-            />
+            /> */}
           </div>
         </div>
       </div>

--- a/src/components/domain/dashboard/CardTable.tsx
+++ b/src/components/domain/dashboard/CardTable.tsx
@@ -1,8 +1,9 @@
 // 카드 리스트들
-import Card, { CardInfo } from '@/components/domain/dashboard/Card'
+import Card from '@/components/domain/dashboard/Card'
+import { CardType } from '@/types/api/cards'
 
 interface CardTableProps {
-  cards: CardInfo[]
+  cards: CardType[]
 }
 
 export default function CardTable({ cards }: CardTableProps) {

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -1,12 +1,11 @@
-// 컬럼 전체 한 세트
+import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import CardTable from '@/components/domain/dashboard/CardTable'
 import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
+import { cardsService } from '@/api/services/cardsServices'
 import { ColumnType } from '@/types/api/columns'
 import { CardType } from '@/types/api/cards'
-import { cardsService } from '@/api/services/cardsServices'
-import { useEffect } from 'react'
-import { useState } from 'react'
+import styles from './column.module.css'
 
 // 내부에서만 사용
 export interface ColumnProps {
@@ -26,20 +25,21 @@ export default function Column({ columnInfo }: ColumnProps) {
   }, [])
 
   return (
-    <div className="min-h-[calc(100vh-4.5rem)] w-[31.4rem] bg-[var(--gray-FAFAFA)] rounded-md shadow-sm flex flex-col">
+    <div className={styles.column}>
       {/* 상단: 컬럼 제목 + 카드 개수 + 설정 버튼 */}
-      <div className="flex items-center justify-between px-[1.6rem] pt-[2.2rem]">
-        <div className="flex items-center gap-[1.2rem]">
-          <div className="flex items-center gap-[0.8rem]">
-            <div className="w-[0.8rem] h-[0.8rem] bg-[#5534DA] rounded-full" />
+      <div className={styles.header}>
+        <div className={styles.titleWrapper}>
+          <div className={styles.dotTitle}>
+            <div className={styles.dot} />
             <span className="text-lg-medium">{columnInfo.title}</span>
           </div>
 
-          <span className="w-[2rem] h-[2rem] rounded-[0.4rem] bg-[#EEEEEE] text-[#787486] text-xs-medium flex items-center justify-center">
+          <span className={styles.cardCount}>
             {/* && 연산자 사용 이유 : getCards는 비동기로 동작, cards가 확정적으로 동작하지 않음. cards가 있을 때만 cards.length가 동작할 수 있게 */}
             {cards && cards.length}
           </span>
         </div>
+
         {/* onClick 이벤트 추가 요망 */}
         <button>
           <Image
@@ -52,13 +52,13 @@ export default function Column({ columnInfo }: ColumnProps) {
       </div>
 
       {/* + 버튼 */}
-      <div className="px-[2rem] pt-[2.5rem] pb-[1.6rem]">
+      <div className={styles.addButtonWrapper}>
         <ButtonDashboard
           // onclickAdd 이벤트 추가 요망
           color="bg-white"
-          className="rounded-[0.6rem] w-full flex justify-center items-center py-[0.9rem]"
+          className={styles.addButton}
           prefix={
-            <div className="w-[22px] h-[22px] shrink-0">
+            <div className={styles.addIcon}>
               <Image
                 src="/assets/icon/add_box.svg"
                 alt="카드 추가 버튼"

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -1,25 +1,30 @@
 // 컬럼 전체 한 세트
 import Image from 'next/image'
 import CardTable from '@/components/domain/dashboard/CardTable'
-import { CardInfo } from '@/components/domain/dashboard/Card'
 import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
-
-export interface ColumnInfo {
-  id: number // 컬럼 ID (수정/삭제 시 사용), 드래그 앤 드롭에서 고유 식별자로 활용
-  title: string // 컬럼 제목
-  dashboardId: number // 이 컬럼이 속한 대시보드 ID, 카드 추가, 수정 시 해당 컬럼이 어느 대시보드에 포함되는지
-  teamId: string // 팀 식별자, 팀 단위 요청 시 API 파라미터로 필요
-  cards: CardInfo[] // 이 컬럼에 포함된 카드 리스트
-  onClickAdd?: () => void // 카드 생성 버튼 핸들러
-  onClickEdit?: () => void // 컬럼 설정(수정/삭제) 버튼 핸들러
-}
+import { ColumnType } from '@/types/api/columns'
+import { CardType } from '@/types/api/cards'
+import { cardsService } from '@/api/services/cardsServices'
+import { useEffect } from 'react'
+import { useState } from 'react'
 
 // 내부에서만 사용
 export interface ColumnProps {
-  columnInfo: ColumnInfo
+  columnInfo: ColumnType
 }
 
 export default function Column({ columnInfo }: ColumnProps) {
+  const [cards, setCards] = useState<CardType[]>()
+
+  const getCards = async () => {
+    const cardsData = await cardsService.getCards(10, columnInfo.id)
+    setCards(cardsData.cards)
+  }
+
+  useEffect(() => {
+    getCards()
+  }, [])
+
   return (
     <div className="min-h-[calc(100vh-4.5rem)] w-[31.4rem] bg-[var(--gray-FAFAFA)] rounded-md shadow-sm flex flex-col">
       {/* 상단: 컬럼 제목 + 카드 개수 + 설정 버튼 */}
@@ -31,11 +36,12 @@ export default function Column({ columnInfo }: ColumnProps) {
           </div>
 
           <span className="w-[2rem] h-[2rem] rounded-[0.4rem] bg-[#EEEEEE] text-[#787486] text-xs-medium flex items-center justify-center">
-            {columnInfo.cards.length}
+            {/* && 연산자 사용 이유 : getCards는 비동기로 동작, cards가 확정적으로 동작하지 않음. cards가 있을 때만 cards.length가 동작할 수 있게 */}
+            {cards && cards.length}
           </span>
         </div>
-
-        <button onClick={columnInfo.onClickEdit}>
+        {/* onClick 이벤트 추가 요망 */}
+        <button>
           <Image
             src="/assets/icon/settings_logo.svg"
             alt="설정 아이콘"
@@ -48,7 +54,7 @@ export default function Column({ columnInfo }: ColumnProps) {
       {/* + 버튼 */}
       <div className="px-[2rem] pt-[2.5rem] pb-[1.6rem]">
         <ButtonDashboard
-          onClick={columnInfo.onClickAdd}
+          // onclickAdd 이벤트 추가 요망
           color="bg-white"
           className="rounded-[0.6rem] w-full flex justify-center items-center py-[0.9rem]"
           prefix={
@@ -67,7 +73,7 @@ export default function Column({ columnInfo }: ColumnProps) {
       </div>
 
       {/* 카드 리스트 */}
-      <CardTable cards={columnInfo.cards} />
+      {cards && <CardTable cards={cards} />}
     </div>
   )
 }

--- a/src/components/domain/dashboard/card.module.css
+++ b/src/components/domain/dashboard/card.module.css
@@ -1,0 +1,61 @@
+.card {
+  width: 100%;
+  border-radius: 0.6rem;
+  background-color: white;
+  border: 0.1rem solid #d9d9d9;
+  overflow: hidden;
+}
+
+.imageWrapper {
+  padding-top: 1.6rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
+.image {
+  width: 100%;
+  height: 16rem;
+  object-fit: cover;
+}
+
+.content {
+  padding-top: 1.6rem;
+  padding-bottom: 1.6rem;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.2rem;
+  line-height: 1.8rem;
+  font-weight: 500;
+  color: var(--gray-787486);
+}
+
+.dateSection {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.calendarIcon {
+  display: inline-block;
+}
+
+.assigneeSection {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/src/components/domain/dashboard/column.module.css
+++ b/src/components/domain/dashboard/column.module.css
@@ -1,0 +1,74 @@
+.column {
+  min-height: calc(100vh - 7rem);
+  width: 31.4rem;
+  background-color: var(--gray-FAFAFA);
+  border-radius: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--gray-D9D9D9);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-left: 1.6rem;
+  padding-right: 1.6rem;
+  padding-top: 2.2rem;
+}
+
+.titleWrapper {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+.dotTitle {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.dot {
+  width: 0.8rem;
+  height: 0.8rem;
+  background-color: #5534da;
+  border-radius: 9999px;
+}
+
+.cardCount {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.4rem;
+  background-color: #eeeeee;
+  color: #787486;
+  font-size: 1.2rem;
+  line-height: 1.8rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.addButtonWrapper {
+  padding-left: 2rem;
+  padding-right: 2rem;
+  padding-top: 2.5rem;
+  padding-bottom: 1.6rem;
+}
+
+.addButton {
+  border-radius: 0.6rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 0.9rem;
+  padding-bottom: 0.9rem;
+}
+
+.addIcon {
+  width: 2.2rem;
+  height: 2.2rem;
+  flex-shrink: 0;
+}

--- a/src/components/domain/modals/TaskCardEditModal.tsx
+++ b/src/components/domain/modals/TaskCardEditModal.tsx
@@ -66,13 +66,13 @@ export default function TaskCardEditModal({
     }
   }
 
-  const handleChangeStatusSelect = (
+  const statusSelectChangeHandler = (
     e: React.ChangeEvent<HTMLSelectElement>
   ) => {
     setStatusValue(e.target.value)
   }
 
-  const handleChangeSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const selectChangeHandler = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectValue(e.target.value)
   }
 
@@ -97,6 +97,10 @@ export default function TaskCardEditModal({
     }
   }
 
+  const handleRemoveTag = (index: number) => {
+    setTags((prevTags) => prevTags.filter((_, i) => i !== index))
+  }
+
   return (
     <div className="fixed inset-0 z-50 bg-[rgba(0,0,0,0.7)] flex justify-center items-center">
       <div className="w-[58.4rem] bg-[var(--white-FFFFFF)] rounded-2xl overflow-auto">
@@ -113,7 +117,7 @@ export default function TaskCardEditModal({
               </label>
               <select
                 value={statusValue}
-                onChange={handleChangeStatusSelect}
+                onChange={statusSelectChangeHandler}
                 className={`w-full h-[4.8rem] px-[1.6rem] py-[1.1rem] border border-[var(--gray-D9D9D9)] rounded-md text-lg-regular outline-none
                   ${
                     statusValue === ''
@@ -139,7 +143,7 @@ export default function TaskCardEditModal({
               </label>
               <select
                 value={selectValue}
-                onChange={handleChangeSelect}
+                onChange={selectChangeHandler}
                 className={`w-full h-[4.8rem] px-[1.6rem] py-[1.1rem] border border-[var(--gray-D9D9D9)] rounded-md text-lg-regular outline-none
                   ${
                     selectValue === ''
@@ -233,7 +237,13 @@ export default function TaskCardEditModal({
             </label>
             <div className="flex flex-wrap w-full min-h-[5rem] px-[1.6rem] py-[1rem] border border-[var(--gray-D9D9D9)] rounded-lg gap-[1rem] focus-within:border-[var(--violet-5534DhA)]">
               {tags.map((tag, idx) => (
-                <Tag key={idx} label={tag.label} color={tag.color} />
+                <Tag
+                  key={idx}
+                  label={tag.label}
+                  color={tag.color}
+                  isDeletable
+                  onDelete={() => handleRemoveTag(idx)}
+                />
               ))}
               <input
                 type="text"

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -1,91 +1,30 @@
 import { useEffect, useState } from 'react'
 import Image from 'next/image'
-import Column, { ColumnInfo } from '@/components/domain/dashboard/Column'
+import Column from '@/components/domain/dashboard/Column' //
 import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
 import Layout from '@/components/layout/layout'
+import { columnsService } from '@/api/services/columnsServices'
+import { ColumnType } from '@/types/api/columns'
+import { useRouter } from 'next/router'
 
 export default function DashboardPage() {
-  const [columns, setColumns] = useState<ColumnInfo[]>([])
+  const [columns, setColumns] = useState<ColumnType[]>([])
+
+  const { query } = useRouter()
+  const dashboardId = Number(query.id)
+
+  const getColumns = async () => {
+    const columnsData = await columnsService.getColumns(dashboardId)
+    setColumns(columnsData.data)
+  }
 
   useEffect(() => {
-    // 임시 더미 데이터
-    const dummy: ColumnInfo[] = [
-      {
-        id: 1,
-        title: 'To Do',
-        dashboardId: 1,
-        teamId: '14-4',
-        cards: [
-          {
-            id: 201,
-            title: '새로운 일정 관리 Taskify',
-            tags: [
-              { label: '프로젝트', color: 'tag-orange' },
-              { label: '백엔드', color: 'tag-pink' },
-              { label: '상', color: 'tag-blue' },
-            ],
-            dueDate: '2025-12-31',
-            assignee: {
-              id: 1,
-              nickname: 'B',
-              profileImageUrl: '/images/profile-b.jpg',
-            },
-            imageUrl: '', // 이미지 없는 카드
-          },
-          {
-            id: 202,
-            title: '새로운 일정 관리 Taskify',
-            tags: [
-              { label: '프로젝트', color: 'tag-orange' },
-              { label: '백엔드', color: 'tag-pink' },
-              { label: '상', color: 'tag-blue' },
-            ],
-            dueDate: '2025-04-24',
-            assignee: {
-              id: 1,
-              nickname: 'B',
-              profileImageUrl: '/images/profile-b.jpg',
-            },
-            imageUrl: '/images/sample-1.jpg', // 실제 이미지 경로
-          },
-          {
-            id: 203,
-            title: '새로운 일정 관리 Taskify',
-            tags: [
-              { label: '프로젝트', color: 'tag-orange' },
-              { label: '상', color: 'tag-blue' },
-            ],
-            dueDate: '2025-04-24',
-            assignee: {
-              id: 1,
-              nickname: 'B',
-              profileImageUrl: '/images/profile-b.jpg',
-            },
-            imageUrl: '', // 이미지 없는 카드
-          },
-        ],
-      },
-      {
-        id: 2,
-        title: 'On Progress',
-        dashboardId: 1,
-        teamId: '14-4',
-        cards: [
-          /* 카드 데이터 */
-        ],
-      },
-      {
-        id: 3,
-        title: 'Done',
-        dashboardId: 1,
-        teamId: '14-4',
-        cards: [
-          /* 카드 데이터 */
-        ],
-      },
-    ]
-    setColumns(dummy)
-  }, [])
+    if (!query.id) return
+    getColumns()
+  }, [query.id])
+
+  // 404 리다이렉트 구현 필요
+  if (!dashboardId) return
 
   return (
     <Layout>

--- a/src/types/api/cards.ts
+++ b/src/types/api/cards.ts
@@ -1,8 +1,10 @@
-export interface Card {
+import { TagProps } from '../common/tag'
+
+export interface CardType {
   id: number
   title: string
   description: string
-  tags: string[]
+  tags: TagProps[]
   dueDate: string
   assignee: {
     profileImageUrl: string
@@ -19,7 +21,7 @@ export interface Card {
 export interface GetCardsResponse {
   cursorId: number
   totalCount: number
-  cards: Card[]
+  cards: CardType[]
 }
 
 export interface CreateCardBody {

--- a/src/types/api/cards.ts
+++ b/src/types/api/cards.ts
@@ -32,7 +32,7 @@ export interface CreateCardBody {
   description: string
   dueDate: string
   tags: string[]
-  imageUrl: string
+  imageUrl: string | null
 }
 
 export interface UpdateCardBody {

--- a/src/types/api/columns.ts
+++ b/src/types/api/columns.ts
@@ -1,4 +1,4 @@
-export interface Column {
+export interface ColumnType {
   id: number
   title: string
   teamId: string
@@ -17,7 +17,7 @@ export interface UpdateColumnBody {
 
 export interface GetColumnsResponse {
   result: string
-  data: Column[]
+  data: ColumnType[]
 }
 
 export interface UploadColumnImageResponse {


### PR DESCRIPTION
## 📌 PR 개요
대시보드 API 연결

## 🏃‍♂️‍➡️ 요구사항
- 

## 🔥 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 대시보드에서 Columns와 Cards API 연결
- tailwind에서 module.css로 파일 분리
- nav바에 맞게 보여지는 높이 조정 후 스크롤바 보이는 문제 해결

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bfba9f2f-6bb4-45ed-a13b-c16e848f2dea)


## 🚧 관련 이슈
SCRUM-160

## 💡 추가 정보
- 현재 데이터를 최상단에서 받아오고 있지 않습니다.
-- index.tsx에서 columns 데이터
-- Column.tsx에서 cards 데이터
다음 구조로 짜여져있습니다.

이것을 최상단 컴포넌트인 index.tsx에서 모든 데이터를 받아와서 하위 컴포넌트로 뿌려주는 것이 맞을지 고민입니다.

고민하는 이유? card에 대한 데이터는 무조건 해당 카드들이 포함되어있는 해당 컬럼 하나 내에서만 사용되는 것이 보장되어있는 형태기 때문
->props drilling을 예방 할 수 있음

(멘토님의 생각도 여쭤보고 싶습니다!!)