### PR TITLE
[Feature/Sidebar]: 사이드바의 대시보드 생성 모달 연동 및 module.css 스타일 변경

### DIFF
--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -1,46 +1,51 @@
-import React from 'react'
+import React, { useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-import styles from './Sidebar.module.css'
+import styles from './sidebar.module.css'
+import DashboardCreateModal from '@/components/domain/modals/dashboardCreateModal/DashboardCreateModal'
 
 export default function Sidebar() {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleOpenModal = () => setIsModalOpen(true)
+  const handleCloseModal = () => setIsModalOpen(false)
+
   return (
     <div className={styles.sidebar}>
+      {/* 로고 영역 */}
       <Link href="/" className={styles.logo}>
         <Image
           src="/assets/icon/logo-icon.svg"
           alt="Taskify Icon"
           className={styles.logoIcon}
-          width={0}
-          height={0}
-          sizes="100vw"
-          style={{ width: '100%', height: 'auto' }}
+          width={30}
+          height={30}
         />
         <Image
           src="/assets/icon/logo-title.svg"
           alt="Taskify Title"
           className={styles.logoTitle}
-          width={0}
-          height={0}
-          sizes="100vw"
-          style={{ width: '100%', height: 'auto' }}
+          width={80}
+          height={24}
         />
       </Link>
 
+      {/* 메뉴 영역 */}
       <ul className={styles.menu}>
         <li className={styles.menuItem}>
-          <span className={`${styles.link} text-xs-semibold`}>Dash Boards</span>
-          <button className={styles.addButton}>
+          <span className={styles.link}>Dash Boards</span>
+          <button onClick={handleOpenModal} className={styles.addButton}>
             <Image
               src="/assets/image/add-box.svg"
-              alt="Add"
-              className=""
+              alt="Add 추가 버튼"
               width={20}
               height={20}
             />
           </button>
         </li>
       </ul>
+
+      {isModalOpen && <DashboardCreateModal onClose={handleCloseModal} />}
     </div>
   )
 }

--- a/src/components/layout/sidebar/sidebar.module.css
+++ b/src/components/layout/sidebar/sidebar.module.css
@@ -42,14 +42,18 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: var(--gray-787486);
   margin-bottom: 2rem;
   width: 100%;
+  color: var(--gray-787486);
 }
 
 .link {
-  flex: 1;
+  font-family: var(--font-family);
   text-decoration: none;
+  flex: 1;
+  font-size: 1.2rem;
+  font-weight: 600;
+  line-height: 2rem;
   color: var(--gray-787486);
 }
 
@@ -61,11 +65,6 @@
   align-items: center;
   justify-content: center;
   padding: 0.4rem;
-}
-
-.addButton img {
-  width: 2rem;
-  height: 2rem;
 }
 
 /* 태블릿 (1023px 이하) */


### PR DESCRIPTION
## 📌 PR 개요
사이드바의 대시보드 생성 모달 연동 및 module.css로 변경
## 🏃‍♂️‍➡️ 요구사항
- [x] ➕ 버튼 클릭 시 대시보드 생성 모달이 나오도록 기능 추가
- [x] 코드 컴포넌트화, JSX 스타일 제거

## 🔥 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
logo-icon.svg, logo-title.svg에 width={0} →  width, height를 실제 픽셀 값으로 수정
기존 JSX에 있던 text-xs-semibold 제거
해당 스타일(font-size, font-weight)을 sidebar.module.css의 .link 클래스에 포함

## 📷 스크린샷 (선택)
![sidebar](https://github.com/user-attachments/assets/e9d1225f-cc31-40f6-8629-d16ba404122b)



## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->