### PR TITLE
[Style/modify-styles-mydashboard/edit] mydashboard 및 edit 페이지 tailwind로 마이그레이션

### DIFF
--- a/src/components/common/commonbutton/commonButton.module.css
+++ b/src/components/common/commonbutton/commonButton.module.css
@@ -12,7 +12,7 @@
 }
 
 .inactive {
-  background-color: var(--gray--9FA6B2);
+  background-color: var(--gray-9FA6B2);
   cursor: not-allowed;
 }
 

--- a/src/components/domain/colorpin/ColorPin.tsx
+++ b/src/components/domain/colorpin/ColorPin.tsx
@@ -2,14 +2,14 @@ import styles from './ColorPin.module.css'
 import ColorBadgeProps from '@/types/common/colorpin'
 
 export default function ColorPin({
-  // id,
+  id,
   color,
   isSelected,
   onClick,
 }: ColorBadgeProps) {
   return (
     <button
-      // key={id}
+      key={id}
       onClick={onClick}
       className={`${styles.color_pin} ${isSelected ? styles.selected : ''}`}
       style={{ backgroundColor: color }}

--- a/src/components/domain/mydashboard/editmydashboardinvitelog/EditMyDashboardInviteLog.tsx
+++ b/src/components/domain/mydashboard/editmydashboardinvitelog/EditMyDashboardInviteLog.tsx
@@ -14,8 +14,9 @@ export default function EditMyDashboardInviteLog() {
               variant="primary"
               padding="0.8rem 1.6rem"
               isActive={true}
-              className={`text-md-medium`}
+              className="button_background_image text-md-medium"
             >
+              {/*이벤트 핸들러 추가하기*/}
               초대하기
             </CommonButton>
           </div>

--- a/src/components/domain/mydashboard/editmydashboardinvitelog/editMyDashboardInviteLog.module.css
+++ b/src/components/domain/mydashboard/editmydashboardinvitelog/editMyDashboardInviteLog.module.css
@@ -10,6 +10,14 @@
   align-items: center;
 }
 
+.button_background_image {
+  background-image: url('/public/assets/icon/add_box_gray.svg');
+  background-repeat: no-repeat;
+  background-size: cover;
+  width: 2.4rem;
+  height: 2.4rem;
+}
+
 .edit_invite_email_header {
   margin-top: 4rem;
   color: var(--gray-9FA6B2);

--- a/src/pages/mydashboard/index.tsx
+++ b/src/pages/mydashboard/index.tsx
@@ -1,4 +1,3 @@
-import styles from './mydashboard.module.css'
 import Image from 'next/image'
 import { useState } from 'react'
 
@@ -41,18 +40,26 @@ export default function MyDashboard() {
         </ButtonDashboard>
 
         {/* 초대받은 대시보드 영역 */}
-        <section className={styles.invite_section}>
-          <div className={`${styles.invite_title} text-2xl-bold`}>
+        <section
+          className={
+            'bg-[var(--white-FFFFFF)] p-[2.4rem_4rem_12rem_4rem] rounded-[1.6rem] shadow-[0_0_0.6rem_rgba(0,0,0,0.05)] max-w-[96rem] mt-[7.4rem]'
+          }
+        >
+          <div
+            className={`text-2xl-bold mb-[6.4rem] text-[var(--black-333236)]`}
+          >
             초대받은 대시보드
           </div>
-          <div className={styles.invite_box}>
+          <div
+            className={'flex flex-col items-center gap-[2.4rem] text-[#8c8c8c]'}
+          >
             <Image
               src="/assets/icon/email.svg"
               alt="email"
               width={100}
               height={100}
             />
-            <div className={styles.invite_message}>
+            <div className={'text-[1.8rem]'}>
               아직 초대받은 대시보드가 없어요
             </div>
           </div>


### PR DESCRIPTION
## 📌 PR 개요

mydashboard 및 edit 페이지 tailwind로 마이그레이션

## 🏃‍♂️‍➡️ 요구사항


## 🔥 변경 사항

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용

- [x] 버튼 공통 컴포넌트 isAcitve color 속성을 시안과 동일하게 변경했습니다.
- [x] 페이지의 재사용성이 적은 코드는 tailwind로 대체 했습니다.

## 📷 스크린샷 (선택)

## 🚧 관련 이슈

## 💡 추가 정보
대시보드 수정 페이지의 초대 내역 컴포넌트 안에 있는 버튼에 백그라운드 이미지를 넣고 있는데, 적용이 안되고 있어서 해결 중입니다 😭