### PR TITLE
[feature/dashboard-editPage-API] edit 페이지 UI 추가 및 API 연결

### DIFF
--- a/src/components/common/commonbutton/commonButton.module.css
+++ b/src/components/common/commonbutton/commonButton.module.css
@@ -13,6 +13,7 @@
 
 .inactive {
   background-color: var(--gray-9FA6B2);
+  color: var(--white-FFFFFF);
   cursor: not-allowed;
 }
 

--- a/src/components/domain/mydashboard/editmydashboardattribute/EditMyDashboardAttribute.tsx
+++ b/src/components/domain/mydashboard/editmydashboardattribute/EditMyDashboardAttribute.tsx
@@ -5,46 +5,57 @@ import { useState, useEffect } from 'react'
 import ColorPin from '@/components/domain/colorpin/ColorPin'
 import { dashboardsService } from '@/api/services/dashboardsServices'
 import { useColorPicker } from '@/hooks/useColorPicker'
-
-// export default function EditPage({ dashboardId }: { dashboardId: number }) {
-//   const [editText, setEditText] = useState('')
-//   const [selectedColor, setSelectedColor] = useState<string | null>(null)
-//   useEffect(() => {
-//     const fetchDashboardData = async () => {
-//       try {
-//         const dashboardData = await dashboardsService.getDashboardsDetail(
-//           dashboardId
-//         )
-//         console.log('대시보드 데이터 오류 검증하기', dashboardData)
-//         setEditText(dashboardData.title)
-//         setSelectedColor(dashboardData.color)
-//       } catch (error) {
-//         console.error('대시보드 데이터를 가져오는 중 오류 발생', error)
-//       }
-//     }
-//     fetchDashboardData()
-//   }, [dashboardId])
-
-//   const handleEditDashboardAttribute = async () => {
-//     console.log('수정된 대시 보드 데이터 서버로 보내기 로직 필요')
-//   }
-
-//   return <div>hi</div>
-
-// 이 부분은 API 연결 때 다시 이용해보는 걸로.. ㅠㅠ 대시 보드 수정하기 버튼을 눌렀을 때
-// edit 페이지로 이동이 되는데, 그 때 dashboardId를 props로 넘겨줘야 API 작업이 가능할 것 같습니다..
+import { useRouter } from 'next/router'
 
 export default function EditMyDashboardAttribute() {
+  const { query } = useRouter()
+  const dashboardId = Number(query.id)
   const [editText, setEditText] = useState('')
+  const [newTitle, setNewTitle] = useState('')
   const { selectedColor, handleColorSelect, COLORS } = useColorPicker()
 
+  useEffect(() => {
+    const fetchDashboardData = async () => {
+      try {
+        const dashboardData = await dashboardsService.getDashboardsDetail(
+          dashboardId
+        )
+        setEditText(dashboardData.title)
+        setNewTitle(dashboardData.title)
+        const selectedColorObject = COLORS.find(
+          (item) => item.color === dashboardData.color
+        )
+        if (selectedColorObject) {
+          handleColorSelect(selectedColorObject)
+        }
+      } catch (error) {
+        console.error('대시보드 데이터를 가져오는 중 오류 발생', error)
+      }
+    }
+    fetchDashboardData()
+  }, [dashboardId])
+
   const handleEditDashboardAttribute = async () => {
-    console.log('수정된 대시 보드 데이터 서버로 보내기 로직 필요')
+    if (!editText) {
+      alert('대시보드 이름을 입력해주세요.')
+      return
+    }
+    try {
+      const body = {
+        title: editText,
+        color: String(selectedColor?.color),
+      }
+      await dashboardsService.putDashboards(dashboardId, body)
+      alert('대시보드 수정이 완료되었습니다.')
+      window.location.reload()
+    } catch (error) {
+      console.error('대시보드 수정 중 오류 발생', error)
+    }
   }
   return (
     <div className={styles.edit_container}>
       <div className={`${styles.dashboard_edit_title_margin} text-2xl-bold`}>
-        비브리지
+        {newTitle}
       </div>
       <div className={`${styles.dashboard_edit_name_margin} text-2lg-medium`}>
         대시보드 이름

--- a/src/components/domain/mydashboard/editmydashboardinvitelog/EditMyDashboardInviteLog.tsx
+++ b/src/components/domain/mydashboard/editmydashboardinvitelog/EditMyDashboardInviteLog.tsx
@@ -1,7 +1,19 @@
 import styles from './editMyDashboardInviteLog.module.css'
 import CommonButton from '@/components/common/commonbutton/CommonButton'
+import Image from 'next/image'
+import ArrowLeft from '../../../../../public/assets/icon/arrow-left-gray.svg'
+import ArrowRight from '../../../../../public/assets/icon/arrow-right-gray.svg'
+import AddBox from '../../../../../public/assets/icon/add-box.svg'
 
 export default function EditMyDashboardInviteLog() {
+  const invitedEmails = [
+    'codeitA@codeit.com',
+    'codeitB@codeit.com',
+    'codeitC@codeit.com',
+    'codeitD@codeit.com',
+    'codeitE@codeit.com',
+  ]
+
   return (
     <>
       <div className={styles.edit_invite_container}>
@@ -9,14 +21,38 @@ export default function EditMyDashboardInviteLog() {
           <div className={`text-2xl-bold`}>초대 내역</div>
           <div className={styles.edit_invite_header_flex_container}>
             <div>1 페이지 중 1</div>
-            {/*페이지네이션 버튼*/}
+            <div>
+              <Image
+                src={ArrowLeft}
+                alt="왼쪽페이지버튼"
+                width={20}
+                height={16}
+                className="object-contain flex"
+              />
+            </div>
+            <div>
+              <Image
+                src={ArrowRight}
+                alt="오른쪽페이지버튼"
+                width={20}
+                height={16}
+                className="object-contain flex"
+              />
+            </div>
             <CommonButton
               variant="primary"
-              padding="0.8rem 1.6rem"
+              padding="0.8rem 2rem 0.7rem 2rem"
               isActive={true}
-              className="button_background_image text-md-medium"
+              className="text-md-medium flex items-center justify-center gap-3"
+              /*이벤트 핸들러 추가하기*/
             >
-              {/*이벤트 핸들러 추가하기*/}
+              <Image
+                src={AddBox}
+                alt="초대하기 버튼"
+                width={16}
+                height={16}
+                className="object-contain"
+              />
               초대하기
             </CommonButton>
           </div>
@@ -24,86 +60,24 @@ export default function EditMyDashboardInviteLog() {
         <div className={`${styles.edit_invite_email_header} text-lg-regular`}>
           이메일
         </div>
-        <div className={styles.invite_cancle_container}>
-          <div>
-            <div className={`${styles.edit_invite_email} text-lg-regular`}>
-              codeitA@codeit.com
-            </div>
-          </div>
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_cancel_button} text-md-medium`}
-            /*이벤트 핸들러 추가하기*/
-          >
-            취소
-          </CommonButton>
-        </div>
 
-        <div className={styles.invite_cancle_container}>
-          <div>
-            <div className={`${styles.edit_invite_email} text-lg-regular`}>
-              codeitB@codeit.com
+        {invitedEmails.map((email, index) => (
+          <div key={index} className={styles.invite_cancle_container}>
+            <div>
+              <div className={`${styles.edit_invite_email} text-lg-regular`}>
+                {email}
+              </div>
             </div>
+            <CommonButton
+              variant="secondary"
+              padding="0.4rem 2.95rem"
+              isActive={true}
+              className={`${styles.edit_cancel_button} text-md-medium`}
+            >
+              취소
+            </CommonButton>
           </div>
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_cancel_button} text-md-medium`}
-          >
-            취소
-          </CommonButton>
-        </div>
-
-        <div className={styles.invite_cancle_container}>
-          <div>
-            <div className={`${styles.edit_invite_email} text-lg-regular`}>
-              codeitC@codeit.com
-            </div>
-          </div>
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_cancel_button} text-md-medium`}
-          >
-            취소
-          </CommonButton>
-        </div>
-
-        <div className={styles.invite_cancle_container}>
-          <div>
-            <div className={`${styles.edit_invite_email} text-lg-regular`}>
-              codeitD@codeit.com
-            </div>
-          </div>
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_cancel_button} text-md-medium`}
-          >
-            취소
-          </CommonButton>
-        </div>
-
-        <div className={styles.invite_cancle_container}>
-          <div>
-            <div className={`${styles.edit_invite_email} text-lg-regular`}>
-              codeitE@codeit.com
-            </div>
-          </div>
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_cancel_button} text-md-medium`}
-          >
-            취소
-          </CommonButton>
-        </div>
+        ))}
       </div>
     </>
   )

--- a/src/components/domain/mydashboard/editmydashboardinvitelog/editMyDashboardInviteLog.module.css
+++ b/src/components/domain/mydashboard/editmydashboardinvitelog/editMyDashboardInviteLog.module.css
@@ -10,14 +10,6 @@
   align-items: center;
 }
 
-.button_background_image {
-  background-image: url('/public/assets/icon/add_box_gray.svg');
-  background-repeat: no-repeat;
-  background-size: cover;
-  width: 2.4rem;
-  height: 2.4rem;
-}
-
 .edit_invite_email_header {
   margin-top: 4rem;
   color: var(--gray-9FA6B2);

--- a/src/components/domain/mydashboard/editmydashboardmember/EditMyDashboardMember.tsx
+++ b/src/components/domain/mydashboard/editmydashboardmember/EditMyDashboardMember.tsx
@@ -1,83 +1,70 @@
 import styles from './editMyDashboardMember.module.css'
 import CommonButton from '@/components/common/commonbutton/CommonButton'
+import Image from 'next/image'
+import ArrowLeft from '../../../../../public/assets/icon/arrow-left-gray.svg'
+import ArrowRight from '../../../../../public/assets/icon/arrow-right-gray.svg'
+import Badge from '@/components/common/badge/Badge'
 
 export default function EditMyDashboardMember() {
+  const members = [
+    { id: 1, name: '정만철' },
+    { id: 2, name: '김태순' },
+    { id: 3, name: '최주협' },
+    { id: 4, name: '윤지현' },
+  ]
   return (
     <>
       <div className={styles.edit_member_container}>
-        <div className={styles.edit_member_header}>
+        <div className={styles.edit_member_flex_container}>
           <div className={`text-2xl-bold`}>구성원</div>
-          <div>
+          <div className={styles.edit_member_flex_container}>
             <div>1 페이지 중 1</div>
-            {/*페이지네이션 버튼*/}
+            <div>
+              <Image
+                src={ArrowLeft}
+                alt="왼쪽페이지버튼"
+                width={20}
+                height={16}
+                className="object-contain flex"
+              />
+            </div>
+            <div>
+              <Image
+                src={ArrowRight}
+                alt="오른쪽페이지버튼"
+                width={20}
+                height={16}
+                className="object-contain flex"
+              />
+            </div>
           </div>
         </div>
         <div className={`${styles.edit_member_name_header} text-lg-regular`}>
           이름
         </div>
-        <div className={styles.member_delete_container}>
-          <div>
-            <div className={`${styles.edit_member_name} text-lg-regular`}>
-              정만철
+
+        {members.map((member) => (
+          <div key={member.id} className={styles.member_delete_container}>
+            <div
+              className={`${styles.edit_member_flex_container} ${styles.edit_member_flex_gap}`}
+            >
+              <Badge nickname={member.name || '닉네임없음'} />
+              <div className={`${styles.edit_member_name} text-lg-regular`}>
+                {member.name}
+              </div>
             </div>
-            {/*profile badge*/}
-          </div>
 
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_delete_button} text-md-medium`}
-            /*이벤트 핸들러 추가하기*/
-          >
-            삭제
-          </CommonButton>
-        </div>
-
-        <div className={styles.member_delete_container}>
-          <div className={`${styles.edit_member_name} text-lg-regular`}>
-            김태순
+            <CommonButton
+              variant="secondary"
+              padding="0.4rem 2.95rem"
+              isActive={true}
+              className={`${styles.edit_delete_button} text-md-medium`}
+              // 이벤트 핸들러 추가하기
+            >
+              삭제
+            </CommonButton>
           </div>
-          {/*profile badge*/}
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_delete_button} text-md-medium`}
-          >
-            삭제
-          </CommonButton>
-        </div>
-
-        <div className={styles.member_delete_container}>
-          <div className={`${styles.edit_member_name} text-lg-regular`}>
-            최주협
-          </div>
-          {/*profile badge*/}
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_delete_button} text-md-medium`}
-          >
-            삭제
-          </CommonButton>
-        </div>
-
-        <div className={styles.member_delete_container}>
-          <div className={`${styles.edit_member_name} text-lg-regular`}>
-            윤지현
-          </div>
-          {/*profile badge*/}
-          <CommonButton
-            variant="secondary"
-            padding="0.4rem 2.95rem"
-            isActive={true}
-            className={`${styles.edit_delete_button} text-md-medium`}
-          >
-            삭제
-          </CommonButton>
-        </div>
+        ))}
       </div>
     </>
   )

--- a/src/components/domain/mydashboard/editmydashboardmember/editMyDashboardMember.module.css
+++ b/src/components/domain/mydashboard/editmydashboardmember/editMyDashboardMember.module.css
@@ -4,10 +4,14 @@
   padding: 2.6rem 2.8rem;
 }
 
-.edit_member_header {
+.edit_member_flex_container {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.edit_member_flex_gap {
+  gap: 1.2rem;
 }
 
 .edit_member_name_header {

--- a/src/pages/dashboard/[id]/edit/index.tsx
+++ b/src/pages/dashboard/[id]/edit/index.tsx
@@ -2,23 +2,59 @@ import EditMyDashboardAttribute from '@/components/domain/mydashboard/editmydash
 import EditMyDashboardMember from '@/components/domain/mydashboard/editmydashboardmember/EditMyDashboardMember'
 import EditMyDashboardInviteLog from '@/components/domain/mydashboard/editmydashboardinvitelog/EditMyDashboardInviteLog'
 import styles from './edit.module.css'
+import { useRouter } from 'next/router'
+import Image from 'next/image'
+import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
+import { dashboardsService } from '@/api/services/dashboardsServices'
 export default function EditPage() {
-  const handleLouterPrev = () => {
-    console.log('이전 페이지로 이동하는 로직 작성하기')
-  }
+  const router = useRouter()
+  const { query } = useRouter()
+  const dashboardId = Number(query.id)
 
-  const handleDashboardDelete = () => {
-    console.log('대시보드 삭제하는 로직 작성하기')
+  const handleDashboardDelete = async () => {
+    try {
+      await dashboardsService.deleteDashboards(dashboardId)
+      alert('대시보드 삭제가 완료되었습니다.')
+      router.push('/mydashboard')
+    } catch (error) {
+      console.error('대시보드 삭제 중 오류 발생', error)
+    }
   }
   return (
     <>
-      <button onClick={handleLouterPrev}>돌아가기</button>
+      <div className="mt-[2rem] ml-[2rem]">
+        <button
+          onClick={() => router.back()}
+          type="button"
+          className="flex items-center gap-[0.6rem] text-[var(--black-333236)] font-[var(--font-family)] cursor-pointer"
+        >
+          <Image
+            src="/assets/image/arrow-left.svg"
+            alt="뒤로가기"
+            width={16}
+            height={16}
+            className="w-[2.0rem] h-[2.0rem]"
+          />
+          <span className="text-lg-medium text-[var(--black-333236)]">
+            돌아가기
+          </span>
+        </button>
+      </div>
       <div className={styles.edit_container}>
         <EditMyDashboardAttribute />
         <EditMyDashboardMember />
         <EditMyDashboardInviteLog />
       </div>
-      <button onClick={handleDashboardDelete}>대시보드 삭제하기</button>
+      <div className="ml-5">
+        <ButtonDashboard
+          className="text-2lg-medium text-[var(--black-333236)]"
+          paddingHeight="py-[1.8rem]"
+          paddingWidth="px-[9.5rem]"
+          onClick={handleDashboardDelete}
+        >
+          대시보드 삭제하기
+        </ButtonDashboard>
+      </div>
     </>
   )
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -10,7 +10,6 @@ import { authService } from '../api/services/authServices'
 import { useAuthStore } from '@/stores/auth'
 import Modal from '@/components/domain/modals/basemodal/Modal'
 import { useFormSignup } from '@/hooks/useFormSignup'
-import Modal from '@/components/domain/modals/Modal'
 
 export default function Login() {
   const [showPassword, setShowPassword] = useState(false)


### PR DESCRIPTION
## 📌 PR 개요
 edit 페이지 UI 추가 및 API 연결

## 🏃‍♂️‍➡️ 요구사항
- [ ]
- [ ]

## 🔥 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용

- [x] CommonButton 공통 컴포넌트 isActive 색깔 피드백 반영
- [x] UI 작업 및 기능 추가(e.g., 뱃지, 버튼 이미지, 돌아가기, 대시보드 삭제하기...)
- [x] API 연결(대시보드 상세 정보 GET, 대시보드 변경 PUT, 대시보드 삭제 DELETE) 


## 📷 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/b754b185-93f7-4de2-895f-3e5dfd40b887)

## 🚧 관련 이슈

JIRA - SCRUM 138(다음에 백로그 한 번에 정리 해서 올리겠습니다..!)

## 💡 추가 정보

* 대시보드 수정 사항 변경 - 수정이 되면 페이지를 한 번 새로고침 하게 해놨습니다.
* 대시보드 삭제 요청 - 대시보드를 삭제했을 때 어디 페이지로 이동할 지 요구사항에 따로 명세가 안 돼 있어서 일단 mydashboard 로 이동하게 해두었습니다.
* 시안에 있는 버튼이 안보여서 있는 버튼 icon을 임의 넣어놨는데, 어떻게 해야 할까요.. 
* 페이지네이션 버튼 컴포넌트화 필요해보입니다!
* 대쉬보드 삭제 → mydashboard로 페이지 이동 → 브라우저 상단 뒤로가기 버튼으로 이미 삭제된 대시보드 페이지 이동 → 그 상태로 대시보드 삭제하기 버튼을 누르면 404(대시보드가 존재하지 않습니다) 에러 반환. **이 현상에 대해 이미 삭제된 대시보드에 대해 페이지를 접근하려고 할 때 리다이렉트를 해야 할 것 같은데 이것도 의견 주세요!!**