### PR TITLE
[Feature/invited-list] 초대받은 대시보드 API 연결

### DIFF
--- a/src/components/domain/mydashboard/dashboardinvitedlist/MyInvitedDashboard.tsx
+++ b/src/components/domain/mydashboard/dashboardinvitedlist/MyInvitedDashboard.tsx
@@ -3,30 +3,44 @@ import styles from './myinviteddashboard.module.css'
 import React, { useState } from 'react'
 import Image from 'next/image'
 import CommonButton from '@/components/common/commonbutton/CommonButton'
+import { Invitation } from '@/types/api/invitations'
+import { invitationsService } from '@/api/services/invitationsServices'
 
-const data = [
-  { name: '프로덕트 디자인', inviter: '손동희' },
-  { name: '새로운 기획 문서', inviter: '유겨영' },
-  { name: '유닛 A', inviter: '장혁' },
-  { name: '유닛 B', inviter: '강나무' },
-  { name: '유닛 C', inviter: '김태현' },
-  { name: '유닛 D', inviter: '김태현' },
-]
+interface MyInvitedDashboardProps {
+  invitedList: Invitation[]
+}
 
-const MyInvitedDashboard = () => {
+const MyInvitedDashboard = ({ invitedList }: MyInvitedDashboardProps) => {
   const [searchTerm, setSearchTerm] = useState('')
-  const [filteredData, setFilteredData] = useState<typeof data>([]) // ✅ 타입 수정
+  const [filteredData, setFilteredData] = useState<Invitation[]>([]) // ✅ 타입 수정
 
   const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
     const keyword = e.target.value
     setSearchTerm(keyword)
 
-    const results = data.filter((item) =>
-      item.name.toLowerCase().includes(keyword.toLowerCase())
+    const results = invitedList.filter((item) =>
+      item.dashboard.title.toLowerCase().includes(keyword.toLowerCase())
     )
 
     setFilteredData(results)
   }
+
+  const handleInviteAcceptButton = async (
+    invitationId: number,
+    isAccept: boolean
+  ) => {
+    try {
+      const bodyData = {
+        inviteAccepted: isAccept ? true : false,
+      }
+      await invitationsService.putInvitations(invitationId, bodyData)
+      console.log('응답 성공!!')
+      window.location.reload()
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.searchdiv}>
@@ -60,15 +74,16 @@ const MyInvitedDashboard = () => {
         </div>
 
         {/* 데이터 목록 */}
-        {(searchTerm ? filteredData : data).map((item, index) => (
+        {(searchTerm ? filteredData : invitedList).map((item, index) => (
           <div key={index} className={styles.invitationlist}>
-            <div>{item.name}</div>
-            <div>{item.inviter}</div>
+            <div>{item.dashboard.title}</div>
+            <div>{item.inviter.nickname}</div>
             <div className={styles.buttonsction}>
               <CommonButton
                 padding="0.7rem 2.9rem"
                 isActive={true}
                 className={styles.customButtonSize}
+                onClick={() => handleInviteAcceptButton(item.id, true)}
               >
                 수락
               </CommonButton>
@@ -76,6 +91,7 @@ const MyInvitedDashboard = () => {
                 padding="0.7rem 2.9rem"
                 variant="secondary"
                 isActive={true}
+                onClick={() => handleInviteAcceptButton(item.id, false)}
               >
                 거절
               </CommonButton>

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -1,28 +1,24 @@
-import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 
-import { dashboardsService } from '@/api/services/dashboardsServices'
+import { useAuthStore } from '@/stores/auth'
 import { membersService } from '@/api/services/membersServices'
+import { dashboardsService } from '@/api/services/dashboardsServices'
+import { columnsService } from '@/api/services/columnsServices'
+import Layout from '@/components/layout/layout'
 import Column from '@/components/domain/dashboard/Column'
 import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
-import Layout from '@/components/layout/layout'
-import { columnsService } from '@/api/services/columnsServices'
-import { ColumnType } from '@/types/api/columns'
-import { useRouter } from 'next/router'
 import TaskCardCreateModal from '@/components/domain/modals/taskcardcreatemodal/TaskCardCreateModal'
-import { useAuthStore } from '@/stores/auth'
+import { ColumnType } from '@/types/api/columns'
 
 export default function DashboardPage() {
+  const { setDashboardTitle, setMembers } = useAuthStore()
   const [columns, setColumns] = useState<ColumnType[]>([])
   const [isCardCreateModalOpen, setIsCardCreateModalOpen] = useState(false)
   const [selectedColumnId, setSelectedColumnId] = useState<number>(-1)
-
-  const { query } = useRouter()
-  const { push } = useRouter()
+  const { query, push } = useRouter()
   const dashboardId = Number(query.id)
-
-  const { setDashboardTitle, setMembers } = useAuthStore()
 
   const getDashboardTitle = async () => {
     try {
@@ -72,7 +68,7 @@ export default function DashboardPage() {
   if (!dashboardId || isNaN(dashboardId)) return null
 
   return (
-    <Layout pageType="dashboard" dashboardId={dashboardId}>
+    <>
       {/* 컬럼 리스트 */}
       <div className="flex overflow-x-auto">
         {columns.map((column) => (
@@ -111,7 +107,7 @@ export default function DashboardPage() {
           handleCardCreateModalClose={handleCardCreateModalClose}
         />
       )}
-    </Layout>
+    </>
   )
 }
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -10,7 +10,6 @@ import { authService } from '../api/services/authServices'
 import { useAuthStore } from '@/stores/auth'
 import Modal from '@/components/domain/modals/basemodal/Modal'
 import { useFormSignup } from '@/hooks/useFormSignup'
-import Modal from '@/components/domain/modals/Modal'
 
 export default function Login() {
   const [showPassword, setShowPassword] = useState(false)

--- a/src/pages/mydashboard/index.tsx
+++ b/src/pages/mydashboard/index.tsx
@@ -8,6 +8,9 @@ import Layout from '@/components/layout/layout'
 import DashboardCreateModal from '@/components/domain/modals/dashboardCreateModal/DashboardCreateModal'
 
 import styles from './mydashboard.module.css'
+import MyInvitedDashboard from '@/components/domain/mydashboard/dashboardinvitedlist/MyInvitedDashboard'
+import { invitationsService } from '@/api/services/invitationsServices'
+import { Invitation } from '@/types/api/invitations'
 
 interface Dashboard {
   id: number
@@ -23,6 +26,7 @@ export default function MyDashboard() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [page, setPage] = useState(1)
   const [dashboards, setDashboards] = useState<Dashboard[]>([])
+  const [invitedList, setInvitedList] = useState<Invitation[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [totalPages, setTotalPages] = useState(0)
@@ -42,14 +46,26 @@ export default function MyDashboard() {
       setTotalPages(totalPages)
     } catch (err) {
       setError('대시보드를 불러오는 데 실패했습니다.')
+      console.error(err)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const fetchInvitedlist = async () => {
+    setLoading(true)
+    try {
+      const res = await invitationsService.getInvitations()
+      setInvitedList(res.invitations)
+    } catch (err) {
+      console.error(err)
     }
   }
 
   // 페이지 변경 시 대시보드 목록을 새로 고침
   useEffect(() => {
     fetchDashboards()
+    fetchInvitedlist()
   }, [page])
 
   const handleCreateDashboardModal = () => {
@@ -74,93 +90,94 @@ export default function MyDashboard() {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.invite_section}>
-        {/* 새로운 대시보드 버튼 */}
-        <ButtonDashboard
-          onClick={handleCreateDashboardModal}
-          paddingHeight="py-[22px]"
-          paddingWidth="px-[99px]"
-          gap="gap-3"
-          className="text-lg-semibold"
-          suffix={
-            <Image
-              src="/assets/icon/add-box.svg"
-              alt="addbutton"
-              width={20}
-              height={20}
-              className="object-contain flex"
-            />
-          }
-        >
-          새로운 대시보드
-        </ButtonDashboard>
+      {/* 새로운 대시보드 버튼 */}
+      <ButtonDashboard
+        onClick={handleCreateDashboardModal}
+        paddingHeight="py-[22px]"
+        paddingWidth="px-[99px]"
+        gap="gap-3"
+        className="text-lg-semibold"
+        suffix={
+          <Image
+            src="/assets/icon/add-box.svg"
+            alt="addbutton"
+            width={20}
+            height={20}
+            className="object-contain flex"
+          />
+        }
+      >
+        새로운 대시보드
+      </ButtonDashboard>
 
-        {/* 로딩 상태 */}
-        {loading && <div>로딩 중...</div>}
+      {/* 로딩 상태 */}
+      {loading && <div>로딩 중...</div>}
 
-        {/* 에러 상태 */}
-        {error && <div>{error}</div>}
+      {/* 에러 상태 */}
+      {error && <div>{error}</div>}
 
-        {/* 대시보드 목록 */}
-        {dashboards.length > 0 ? (
-          <>
-            {dashboards
-              .slice((page - 1) * dashboardsPerPage, page * dashboardsPerPage)
-              .map((dashboard) => (
-                <DashboardListButton key={dashboard.id}>
-                  {dashboard.title}
-                  {dashboard.createdByMe && (
-                    <Image
-                      src="/assets/icon/crown.svg"
-                      alt="크라운"
-                      width={16}
-                      height={16}
-                      className="object-contain"
-                    />
-                  )}
-                </DashboardListButton>
-              ))}
-
-            {/* 페이지네이션 */}
-            <div className={`${styles.page_wrapper} text-md-regular`}>
-              <div className={styles.botton_gap}>
-                <span>
-                  {page} 페이지 중 {totalPages}
-                </span>
-              </div>
-              <button
-                onClick={handlePrev}
-                disabled={page === 1}
-                className={styles.page_button_left}
-              >
-                <div className={styles.crown_center}>
+      {/* 대시보드 목록 */}
+      {dashboards.length > 0 && (
+        <>
+          {dashboards
+            .slice((page - 1) * dashboardsPerPage, page * dashboardsPerPage)
+            .map((dashboard) => (
+              <DashboardListButton key={dashboard.id}>
+                {dashboard.title}
+                {dashboard.createdByMe && (
                   <Image
-                    src="/assets/image/arrow-left.svg"
-                    alt="왼쪽 페이지 버튼"
-                    width={6}
+                    src="/assets/icon/crown.svg"
+                    alt="크라운"
+                    width={16}
                     height={16}
-                    className="object-contain flex"
+                    className="object-contain"
                   />
-                </div>
-              </button>
-              <button
-                onClick={handleNext}
-                disabled={page === totalPages}
-                className={styles.page_button_right}
-              >
-                <div className={styles.crown_center}>
-                  <Image
-                    src="/assets/image/arrow-right.svg"
-                    alt="오른쪽 페이지 버튼"
-                    width={6}
-                    height={16}
-                    className="object-contain flex"
-                  />
-                </div>
-              </button>
+                )}
+              </DashboardListButton>
+            ))}
+
+          {/* 페이지네이션 */}
+          <div className={`${styles.page_wrapper} text-md-regular`}>
+            <div className={styles.botton_gap}>
+              <span>
+                {page} 페이지 중 {totalPages}
+              </span>
             </div>
-          </>
-        ) : (
+            <button
+              onClick={handlePrev}
+              disabled={page === 1}
+              className={styles.page_button_left}
+            >
+              <div className={styles.crown_center}>
+                <Image
+                  src="/assets/image/arrow-left.svg"
+                  alt="왼쪽 페이지 버튼"
+                  width={6}
+                  height={16}
+                  className="object-contain flex"
+                />
+              </div>
+            </button>
+            <button
+              onClick={handleNext}
+              disabled={page === totalPages}
+              className={styles.page_button_right}
+            >
+              <div className={styles.crown_center}>
+                <Image
+                  src="/assets/image/arrow-right.svg"
+                  alt="오른쪽 페이지 버튼"
+                  width={6}
+                  height={16}
+                  className="object-contain flex"
+                />
+              </div>
+            </button>
+          </div>
+        </>
+      )}
+      {invitedList && !invitedList.length ? (
+        <div className={styles.invite_section}>
           <div className="flex flex-col items-center gap-[2.4rem] text-[#8c8c8c]">
             <Image
               src="/assets/icon/email.svg"
@@ -170,8 +187,10 @@ export default function MyDashboard() {
             />
             <div className="text-[1.8rem]">아직 초대받은 대시보드가 없어요</div>
           </div>
-        )}
-      </div>
+        </div>
+      ) : (
+        <MyInvitedDashboard invitedList={invitedList} />
+      )}
 
       {/* 대시보드 생성 모달 dfasdf*/}
       {isModalOpen && (


### PR DESCRIPTION
## 📌 PR 개요
초대받은 대시보드 API 연결

## 🏃‍♂️‍➡️ 요구사항
### 나의 대시보드( “ /mydashboard “ )
- [x]  초대받은 대시보드에서 이름(title)으로 검색이 가능하도록 하세요 (키워드가 이름에 일부라도 포함되면 모두 검색되도록 하세요).
- [x]  초대받은 대시보드에서 ‘생성' 버튼을 누르면 대시보드가 추가되도록 하세요
- [x]  초대받은 대시보드에서 '거절' 버튼을 누르면 해당 대시보드는 삭제되도록 하세요.

## 🔥 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- layout이 겹치는 문제 해결
- 초대받은 목록이 없을 때에는 `아직 초대받은 대시보드가 없어요`로 뜨게
- 생성 버튼과 거절 버튼을 눌렀을 때 해당 기능이 잘 되게 완료
- 초대받은 대시보드에서 검색 시에, 대시보드명을 입력하면 잘 동작하는 부분까지 확인 완료

## 📷 스크린샷 (선택)
![초대받은 대시보드](https://github.com/user-attachments/assets/a0c1f11e-ba29-4e06-baf1-c21688524d62)
생성과 거절 버튼이 잘 동작하게 API 연결 완료

## 🚧 관련 이슈
SCRUM - 70, 71, 72

## 💡 추가 정보
- 처음에 잠깐 `아직 초대받은 대시보드가 없어요`가 나타나, 추후에 리다이렉트 구현 필요
- 스타일링 수정 필요
- 새로운 대시보드 추가되는 부분의 스타일링은 손 봐야합니다