### PR TITLE
[Feature/dashboard-member-api] 대시보드 멤버 관리와 관련된 기능들 구현

### DIFF
--- a/src/components/domain/modals/taskcardcreatemodal/TaskCardCreateModal.tsx
+++ b/src/components/domain/modals/taskcardcreatemodal/TaskCardCreateModal.tsx
@@ -46,13 +46,6 @@ export default function TaskCardCreateModal({
     ...TAG_COLORS,
   ])
   const [isButtonDisable, setIsButtonDisable] = useState(true)
-  // const users = [
-  //   { id: 1, name: '김이영', badgeColor: '#EF4444' },
-  //   { id: 2, name: '박해일', badgeColor: '#34D399' },
-  //   { id: 3, name: '이원구', badgeColor: '#FBBF24' },
-  //   { id: 4, name: '이아이', badgeColor: '#22C55E' },
-  //   { id: 5, name: '이지사', badgeColor: '#5534DA' },
-  // ]
   const dashboardMembers = useDashboardMembers((state) => state.members)
   const users = dashboardMembers.map((user) => ({
     id: user.id,

--- a/src/components/layout/gnb/HomeNavBar.tsx
+++ b/src/components/layout/gnb/HomeNavBar.tsx
@@ -4,17 +4,15 @@ import clsx from 'clsx'
 
 import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
 import Badge from '@/components/common/badge/Badge'
+import { useDashboardMembers } from '@/stores/dashboardMembers'
+import { useAuthStore } from '@/stores/auth'
 
 interface HomeNavBarProps {
   pageType: 'mydashboard' | 'dashboard' | 'mypage'
   dashboardId: number
   dashboardTitle: string
   hasCrown: boolean
-  userName: string
-  memberCount: number
-  members: { email: string; name: string }[]
   onInviteClick: () => void
-  profileImage?: string
 }
 
 export default function HomeNavBar({
@@ -22,12 +20,12 @@ export default function HomeNavBar({
   pageType,
   dashboardTitle,
   hasCrown,
-  userName,
-  memberCount,
-  members,
   onInviteClick,
-  profileImage,
 }: HomeNavBarProps) {
+  const { userData } = useAuthStore()
+  const { members } = useDashboardMembers()
+  console.log(dashboardId)
+
   // 제목 결정
   const getTitle = () => {
     switch (pageType) {
@@ -47,7 +45,7 @@ export default function HomeNavBar({
 
   // 초대 및 관리 버튼 등 표시 여부
   const showDashboardControls = pageType !== 'mydashboard'
-
+  console.log(members)
   // 멤버 정보 텍스트
   const memberInfo =
     pageType === 'dashboard'
@@ -139,9 +137,9 @@ export default function HomeNavBar({
           className={clsx(styles.flex_center_space_between, styles.nav_right)}
         >
           <div className={styles.profile_image}>
-            {profileImage ? (
+            {userData?.profileImage ? (
               <Image
-                src={profileImage}
+                src={userData.profileImage}
                 alt="Profile Image"
                 width={40}
                 height={40}
@@ -151,10 +149,12 @@ export default function HomeNavBar({
                 }}
               />
             ) : (
-              <Badge nickname={userName} />
+              <Badge nickname={userData ? userData.nickname : ''} />
             )}
           </div>
-          <div className={`${styles.name} text-lg-medium`}>{userName}</div>
+          <div className={`${styles.name} text-lg-medium`}>
+            {userData?.nickname}
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -2,9 +2,6 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
-import { useAuthStore } from '@/stores/auth'
-import { membersService } from '@/api/services/membersServices'
-import { dashboardsService } from '@/api/services/dashboardsServices'
 import { columnsService } from '@/api/services/columnsServices'
 import Layout from '@/components/layout/layout'
 import Column from '@/components/domain/dashboard/Column'
@@ -13,30 +10,11 @@ import TaskCardCreateModal from '@/components/domain/modals/taskcardcreatemodal/
 import { ColumnType } from '@/types/api/columns'
 
 export default function DashboardPage() {
-  const { setDashboardTitle, setMembers } = useAuthStore()
   const [columns, setColumns] = useState<ColumnType[]>([])
   const [isCardCreateModalOpen, setIsCardCreateModalOpen] = useState(false)
   const [selectedColumnId, setSelectedColumnId] = useState<number>(-1)
   const { query, push } = useRouter()
   const dashboardId = Number(query.id)
-
-  const getDashboardTitle = async () => {
-    try {
-      const data = await dashboardsService.getDashboardsDetail(dashboardId)
-      setDashboardTitle(data.title)
-    } catch (error) {
-      console.error('대시보드 정보 불러오기 실패:', error)
-    }
-  }
-  const getDashboardMembers = async () => {
-    try {
-      const data = await membersService.getMembers(1, 20, dashboardId)
-
-      setMembers(data.members)
-    } catch (error) {
-      console.error('대시보드 정보 불러오기 실패:', error)
-    }
-  }
 
   const getColumns = async () => {
     const columnsData = await columnsService.getColumns(dashboardId)
@@ -59,8 +37,6 @@ export default function DashboardPage() {
       push('/404')
     } else {
       getColumns()
-      getDashboardMembers()
-      getDashboardTitle()
     }
   }, [query.id, dashboardId, push])
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -41,10 +41,9 @@ export default function Login() {
       const response = await authService.postAuth(body)
 
       const accessToken = response.accessToken
-      const userId = response.user.id
       const userData = response.user
 
-      setAuth(accessToken, userId)
+      setAuth(accessToken)
       setUserData(userData)
       router.push('/mydashboard')
     } catch (error) {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -7,25 +7,11 @@ type UserData = {
   profileImage?: string // 프로필 이미지는 선택 사항
 }
 
-type Member = {
-  id: number
-  email: string
-  nickname: string
-}
-
 type AuthState = {
   accessToken: string | null
-  userId: number | null
   userData: UserData | null
-  profileImageUrl: string | null
-  members: Member[]
-  dashboardTitle: string | null
-  userName: string | null
-  setAuth: (token: string, userId: number) => void
+  setAuth: (token: string) => void
   setUserData: (data: UserData) => void
-  setProfileImageUrl: (url: string) => void
-  setMembers: (members: Member[]) => void
-  setDashboardTitle: (title: string) => void
   clearAuth: () => void
 }
 
@@ -33,33 +19,17 @@ export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       accessToken: null,
-      userId: null,
       userData: null,
-      profileImageUrl: null, // 프로필 이미지 URL 상태 추가
-      userName: null,
-      members: [],
-      dashboardTitle: null,
-      setAuth: (token, userId) => set({ accessToken: token, userId }),
+      setAuth: (token) => set({ accessToken: token }),
       setUserData: (data) => {
         set({
           userData: data,
-          userName: data.nickname,
-          profileImageUrl: data.profileImage || null, // 프로필 이미지 URL을 상태에 반영
         })
       },
-      // ...
-
-      setProfileImageUrl: (url) => set({ profileImageUrl: url }), // 프로필 이미지 URL 업데이트
-      setMembers: (members) => set({ members }),
-      setDashboardTitle: (title) => set({ dashboardTitle: title }),
       clearAuth: () =>
         set({
           accessToken: null,
-          userId: null,
           userData: null,
-          userName: null,
-          members: [],
-          dashboardTitle: null,
         }),
     }),
     {


### PR DESCRIPTION
## 📌 PR 개요
대시보드 멤버 관리와 관련된 기능들 구현

## 🏃‍♂️‍➡️ 요구사항
### 대시보드 상세 페이지 ( “ /dashboard/{dashboardid}“ )
- [x] 네비게이션 상단 오른쪽에 초대받은 멤버가 보이도록 하세요.
- [x] 내가 만든 대시보드 이름 우측에는 왕관 모양이 보이도록 하세요.

### 할 일 생성 모달(/dashboard/{dashboardid})
- [x] 담당자는 드롭다운으로 초대받은 인원만 선택할 수 있도록 하세요.

## 🔥 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- authStore에 불필요하게 들어가는 데이터(ImageUrl, username, dashboardtitle, etc...) 제외
  - 전부 userData로 통합 처리
- `useDashboardInfo.ts` 커스텀 훅 사용 안함
  - 대시보드 id를 강제로 100으로 불러오게 하는 원인임을 확인하여 제거
 - 대시보드에 접근가능한 멤버들 전역상태로 관리
   - 이를 기반으로 할 일 생성 모달에서 담당자 받아오기 가능해짐
   - **다만, 네비게이션 상단 오른쪽에 초대받은 멤버가 나열되어 보이도록 스타일 수정 필요**

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/b4c420e2-e842-4dad-998b-aa8d180bd9ce)
대시보드에서 왕관 표시 및 멤버들 수, 프로필, 닉네임 뜨는 HomeNavBar

![image](https://github.com/user-attachments/assets/ea653c94-fab1-4558-a439-9699a8b13d30)
할 일 생성 모달에서 담당자 받아와지는 모습


## 🚧 관련 이슈
SCRUM - 43

## 💡 추가 정보
