### PR TITLE
[Feature/dashboard-edit-connect] 대시보드 수정 페이지 연결 및 레이아웃 추가

### DIFF
--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -11,11 +11,13 @@ import styles from './column.module.css'
 export interface ColumnProps {
   columnInfo: ColumnType
   handleCardCreateModalOpen: (columnId: number) => void
+  handleColumnFixModalOpen: (columnId: number) => void
 }
 
 export default function Column({
   columnInfo,
   handleCardCreateModalOpen,
+  handleColumnFixModalOpen,
 }: ColumnProps) {
   const [cards, setCards] = useState<CardType[]>()
 
@@ -45,7 +47,7 @@ export default function Column({
         </div>
 
         {/* onClick 이벤트 추가 요망 */}
-        <button>
+        <button onClick={() => handleColumnFixModalOpen(columnInfo.id)}>
           <Image
             src="/assets/icon/settings-logo.svg"
             alt="설정 아이콘"

--- a/src/components/layout/gnb/HomeNavBar.tsx
+++ b/src/components/layout/gnb/HomeNavBar.tsx
@@ -6,6 +6,7 @@ import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
 import Badge from '@/components/common/badge/Badge'
 import { useDashboardMembers } from '@/stores/dashboardMembers'
 import { useAuthStore } from '@/stores/auth'
+import Link from 'next/link'
 
 interface HomeNavBarProps {
   pageType: 'mydashboard' | 'dashboard' | 'mypage'
@@ -82,27 +83,29 @@ export default function HomeNavBar({
             )}
           >
             <div className={styles.nav_right_center_border_setting}>
-              <ButtonDashboard
-                paddingHeight="py-3"
-                paddingWidth="px-6.5"
-                gap="gap-2"
-                style={{
-                  color: 'var(--gray-787486)',
-                  objectFit: 'contain',
-                  display: 'flex',
-                }}
-                prefix={
-                  <Image
-                    src="/assets/icon/settings-logo.svg"
-                    alt="설정"
-                    width={20}
-                    height={20}
-                    className={styles.icon}
-                  />
-                }
-              >
-                관리
-              </ButtonDashboard>
+              <Link href={`/dashboard/${dashboardId}/edit`}>
+                <ButtonDashboard
+                  paddingHeight="py-3"
+                  paddingWidth="px-6.5"
+                  gap="gap-2"
+                  style={{
+                    color: 'var(--gray-787486)',
+                    objectFit: 'contain',
+                    display: 'flex',
+                  }}
+                  prefix={
+                    <Image
+                      src="/assets/icon/settings-logo.svg"
+                      alt="설정"
+                      width={20}
+                      height={20}
+                      className={styles.icon}
+                    />
+                  }
+                >
+                  관리
+                </ButtonDashboard>
+              </Link>
             </div>
             <div className={styles.button_invitation}>
               <ButtonDashboard

--- a/src/pages/dashboard/[id]/edit/index.tsx
+++ b/src/pages/dashboard/[id]/edit/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import Image from 'next/image'
 import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
 import { dashboardsService } from '@/api/services/dashboardsServices'
+import Layout from '@/components/layout/layout'
 export default function EditPage() {
   const router = useRouter()
   const { query } = useRouter()
@@ -58,10 +59,6 @@ export default function EditPage() {
     </>
   )
 }
-// EditPage.getLayout = function getLayout(page: React.ReactElement) {
-//   return (
-//     <Layout pageType="dashboard" dashboardId={1}>
-//       {page}
-//     </Layout>
-//   )
-// }
+EditPage.getLayout = function getLayout(page: React.ReactElement) {
+  return <Layout pageType="dashboard">{page}</Layout>
+}


### PR DESCRIPTION
## 📌 PR 개요
HomeNavBar에서 관리 버튼 클릭 시 이동 및 Layout 추가


## 🏃‍♂️‍➡️ 요구사항
### 대시보드 상세 페이지( “ /dashboard/{dashboardid}“ )
- [x] '관리' 버튼을 클릭하면 /dashboard/{dashboardid}/edit로 이동하게 하세요.

## 🔥 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- HomeNavBar에서 관리 버튼 클릭 시 이동
- 대시보드 수정 페이지 Layout 추가
   - 대시보드 수정 페이지에서 돌아가기 버튼 클릭 시 대시보드 이동도 원활하게 동작

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/488e37e2-9b0a-49cf-92dd-6ac9ef402321)
HomeNavBar에서 관리 버튼 클릭 시 이동

## 🚧 관련 이슈
SCRUM - 114

## 💡 추가 정보
