### PR TITLE
[Feature/nav-management-button] 대시보드 권한이 있는 경우에만 관리 버튼

### DIFF
--- a/src/components/layout/gnb/HomeNavBar.tsx
+++ b/src/components/layout/gnb/HomeNavBar.tsx
@@ -82,31 +82,33 @@ export default function HomeNavBar({
               styles.nav_right_center_border
             )}
           >
-            <div className={styles.nav_right_center_border_setting}>
-              <Link href={`/dashboard/${dashboardId}/edit`}>
-                <ButtonDashboard
-                  paddingHeight="py-3"
-                  paddingWidth="px-6.5"
-                  gap="gap-2"
-                  style={{
-                    color: 'var(--gray-787486)',
-                    objectFit: 'contain',
-                    display: 'flex',
-                  }}
-                  prefix={
-                    <Image
-                      src="/assets/icon/settings-logo.svg"
-                      alt="설정"
-                      width={20}
-                      height={20}
-                      className={styles.icon}
-                    />
-                  }
-                >
-                  관리
-                </ButtonDashboard>
-              </Link>
-            </div>
+            {hasCrown && (
+              <div className={styles.nav_right_center_border_setting}>
+                <Link href={`/dashboard/${dashboardId}/edit`}>
+                  <ButtonDashboard
+                    paddingHeight="py-3"
+                    paddingWidth="px-6.5"
+                    gap="gap-2"
+                    style={{
+                      color: 'var(--gray-787486)',
+                      objectFit: 'contain',
+                      display: 'flex',
+                    }}
+                    prefix={
+                      <Image
+                        src="/assets/icon/settings-logo.svg"
+                        alt="설정"
+                        width={20}
+                        height={20}
+                        className={styles.icon}
+                      />
+                    }
+                  >
+                    관리
+                  </ButtonDashboard>
+                </Link>
+              </div>
+            )}
             <div className={styles.button_invitation}>
               <ButtonDashboard
                 paddingHeight="py-3"


### PR DESCRIPTION
## 📌 PR 개요
대시보드 권한이 있는 경우에만 관리 버튼 보이도록 설정

## 🏃‍♂️‍➡️ 요구사항
- [ ]

## 🔥 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 관리 버튼에서 구성원 삭제 여부, 초대 내역 확인 및 삭제 여부 등이 표시 되기 때문에 대시보드의 권한이 있을 때에만 nav바에 관리 버튼이 보이도록 수정

## 📷 스크린샷 (선택)
![image (5)](https://github.com/user-attachments/assets/d6889505-ce30-4dba-bbe6-b6620305f09a)
대시보드 권한이 없으면 관리 버튼 안 보이게
![image (6)](https://github.com/user-attachments/assets/4ed7607c-7d11-4921-b96c-edc5f9c65877)
대시보드 권한이 있으면 관리 버튼 보이게


## 🚧 관련 이슈


## 💡 추가 정보
- 왕관 표시가 다음의 역할을 하기 때문에 왕관 표시가 나타날 때에만 관리 버튼이 보이도록 코드 구현