### PR TITLE
[Feature/sidebar-api] 사이드바 API 연동 및 페이지네이션 기능 추가

### DIFF
--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -11,13 +11,11 @@ import styles from './column.module.css'
 export interface ColumnProps {
   columnInfo: ColumnType
   handleCardCreateModalOpen: (columnId: number) => void
-  handleColumnFixModalOpen: (columnId: number) => void
 }
 
 export default function Column({
   columnInfo,
   handleCardCreateModalOpen,
-  handleColumnFixModalOpen,
 }: ColumnProps) {
   const [cards, setCards] = useState<CardType[]>()
 
@@ -47,7 +45,7 @@ export default function Column({
         </div>
 
         {/* onClick 이벤트 추가 요망 */}
-        <button onClick={() => handleColumnFixModalOpen(columnInfo.id)}>
+        <button>
           <Image
             src="/assets/icon/settings-logo.svg"
             alt="설정 아이콘"

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -120,7 +120,7 @@ export default function Layout({ children, pageType }: LayoutProps) {
   return (
     <div className="flex h-screen">
       <div className="w-[300px] shrink-0">
-        <Sidebar />
+        <Sidebar currentDashboardId={dashboardId} />
       </div>
       <div className="flex flex-col flex-1">
         <header className="h-[70px] shrink-0 border-b border-[var(--gray-D9D9D9)] bg-white">

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -13,14 +13,26 @@ export default function Sidebar({
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [dashboardList, setDashboardList] = useState<Dashboard[]>([])
+  const [totalCount, setTotalCount] = useState(0)
+  const [page, setPage] = useState(1)
 
   const handleOpenModal = () => setIsModalOpen(true)
   const handleCloseModal = () => setIsModalOpen(false)
 
+  const handlePageMove = (direction: string) => {
+    if (page !== 1 && direction == 'left') {
+      setPage((prev) => prev - 1)
+    }
+    if (Math.ceil(totalCount / 10) !== page && direction == 'right') {
+      setPage((prev) => prev + 1)
+    }
+  }
+
   const getDashboardList = async () => {
     try {
-      const res = await dashboardsService.getDashboards('infiniteScroll')
+      const res = await dashboardsService.getDashboards('pagination', page)
       setDashboardList(res.dashboards)
+      setTotalCount(res.totalCount)
     } catch (err) {
       console.error(err)
     }
@@ -28,7 +40,7 @@ export default function Sidebar({
 
   useEffect(() => {
     getDashboardList()
-  }, [])
+  }, [page])
 
   return (
     <div className={styles.sidebar}>
@@ -63,38 +75,68 @@ export default function Sidebar({
             />
           </button>
         </li>
-        {dashboardList &&
-          dashboardList.length &&
-          dashboardList.map((dashboard) => (
-            <li key={dashboard.id}>
-              <Link
-                className={`flex items-center gap-[16px] mb-[8px] px-[12px] py-[12px] rounded-[4px] ${
-                  currentDashboardId === dashboard.id ? 'bg-[#F1EFFD]' : ''
-                }`}
-                href={`/dashboard/${dashboard.id}`}
-              >
-                <div
-                  className="w-[8px] h-[8px] rounded-full"
-                  style={{ backgroundColor: dashboard.color }}
-                ></div>
-                <div className="flex items-center gap-[6px]">
-                  <div className="text-2lg-medium text-[#787486]">
-                    {dashboard.title}
+        <ul className="h-[580px]">
+          {dashboardList &&
+            dashboardList.length &&
+            dashboardList.map((dashboard) => (
+              <li key={dashboard.id}>
+                <Link
+                  className={`flex items-center gap-[16px] mb-[8px] px-[12px] py-[12px] rounded-[4px] ${
+                    currentDashboardId === dashboard.id ? 'bg-[#F1EFFD]' : ''
+                  }`}
+                  href={`/dashboard/${dashboard.id}`}
+                >
+                  <div
+                    className="w-[8px] h-[8px] rounded-full"
+                    style={{ backgroundColor: dashboard.color }}
+                  ></div>
+                  <div className="flex items-center gap-[6px]">
+                    <div className="text-2lg-medium text-[#787486]">
+                      {dashboard.title}
+                    </div>
+                    {dashboard.createdByMe && (
+                      <Image
+                        src="/assets/icon/crown.svg"
+                        alt="왕관"
+                        width={20}
+                        height={16}
+                      />
+                    )}
                   </div>
-                  {dashboard.createdByMe && (
-                    <Image
-                      src="/assets/icon/crown.svg"
-                      alt="왕관"
-                      width={20}
-                      height={16}
-                    />
-                  )}
-                </div>
-              </Link>
-            </li>
-          ))}
+                </Link>
+              </li>
+            ))}
+        </ul>
       </ul>
-      <ul></ul>
+      <article className="w-full flex justify-between items-center mt-[32px]">
+        <button
+          className="w-[40px] h-[40px] border-2 border-[#D9D9D9] rounded-l-[6px] flex justify-center items-center cursor-pointer"
+          onClick={() => handlePageMove('left')}
+        >
+          <Image
+            className="w-[16px] h-[16px]"
+            src="/assets/icon/arrow-left-gray.svg"
+            width={16}
+            height={16}
+            alt="왼쪽 화살표"
+          />
+        </button>
+        <div>
+          {page} / {Math.ceil(totalCount / 10)}
+        </div>
+        <button
+          className="w-[40px] h-[40px] border-2 border-[#D9D9D9] rounded-r-[6px] flex justify-center items-center cursor-pointer"
+          onClick={() => handlePageMove('right')}
+        >
+          <Image
+            className="w-[16px] h-[16px]"
+            src="/assets/icon/arrow-right-gray.svg"
+            width={16}
+            height={16}
+            alt="오른른쪽 화살표"
+          />
+        </button>
+      </article>
 
       {isModalOpen && <DashboardCreateModal onClose={handleCloseModal} />}
     </div>

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -1,14 +1,34 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import styles from './sidebar.module.css'
 import DashboardCreateModal from '@/components/domain/modals/dashboardCreateModal/DashboardCreateModal'
+import { Dashboard } from '@/types/api/dashboards'
+import { dashboardsService } from '@/api/services/dashboardsServices'
 
-export default function Sidebar() {
+export default function Sidebar({
+  currentDashboardId,
+}: {
+  currentDashboardId: number
+}) {
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [dashboardList, setDashboardList] = useState<Dashboard[]>([])
 
   const handleOpenModal = () => setIsModalOpen(true)
   const handleCloseModal = () => setIsModalOpen(false)
+
+  const getDashboardList = async () => {
+    try {
+      const res = await dashboardsService.getDashboards('infiniteScroll')
+      setDashboardList(res.dashboards)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  useEffect(() => {
+    getDashboardList()
+  }, [])
 
   return (
     <div className={styles.sidebar}>
@@ -43,7 +63,38 @@ export default function Sidebar() {
             />
           </button>
         </li>
+        {dashboardList &&
+          dashboardList.length &&
+          dashboardList.map((dashboard) => (
+            <li key={dashboard.id}>
+              <Link
+                className={`flex items-center gap-[16px] mb-[8px] px-[12px] py-[12px] rounded-[4px] ${
+                  currentDashboardId === dashboard.id ? 'bg-[#F1EFFD]' : ''
+                }`}
+                href={`/dashboard/${dashboard.id}`}
+              >
+                <div
+                  className="w-[8px] h-[8px] rounded-full"
+                  style={{ backgroundColor: dashboard.color }}
+                ></div>
+                <div className="flex items-center gap-[6px]">
+                  <div className="text-2lg-medium text-[#787486]">
+                    {dashboard.title}
+                  </div>
+                  {dashboard.createdByMe && (
+                    <Image
+                      src="/assets/icon/crown.svg"
+                      alt="왕관"
+                      width={20}
+                      height={16}
+                    />
+                  )}
+                </div>
+              </Link>
+            </li>
+          ))}
       </ul>
+      <ul></ul>
 
       {isModalOpen && <DashboardCreateModal onClose={handleCloseModal} />}
     </div>

--- a/src/components/layout/sidebar/sidebar.module.css
+++ b/src/components/layout/sidebar/sidebar.module.css
@@ -3,7 +3,7 @@
   left: 0;
   position: fixed;
   width: 30rem;
-  padding: 2rem 2.35rem;
+  padding: 2rem 1.2rem 0 0.8rem;
   height: 100vh;
   background-color: var(--white-FFFFFF);
   border-right: 1px solid var(--gray-D9D9D9);


### PR DESCRIPTION
## 📌 PR 개요
사이드바 API 연동 및 페이지네이션 기능 추가

## 🏃‍♂️‍➡️ 요구사항
- [x]  각 대시보드를 클릭하면 `/dashboard/{dashboardid}` 페이지로 이동하게 하세요.
- [x]  사이드바 대시보드는 페이지네이션으로 구현하세요 (무한 스크롤은 사용하지 마세요).
- [x]  '+' 버튼을 클릭하면 대시보드 생성 모달이 나타나도록 하세요.

## 🔥 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 페이지네이션 구현
- 대시보드 리스트 API 연결 및 구현
- 해당 대시보드로 이동 및 연보라색 배경
- 대시보드 주인일 시, 왕관 이모티콘 붙이기

## 📷 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f78309a2-e3b2-4e35-bc2f-9ade63f70835)
사이드바 첫 페이지
![image](https://github.com/user-attachments/assets/df12f8f6-57b2-4025-a255-10f9501726ad)
사이드바 마지막 페이지

## 🚧 관련 이슈


## 💡 추가 정보
- tailwind로 해서 수정 필요합니다.
- 페이지네이션 버튼은 양쪽으로 배치하고 중간에 페이지 수 나오게 작성했는데, 아래 이미지와 같이 디자인 수정하면 좋을 것 같아요
![image](https://github.com/user-attachments/assets/615c3eeb-e10a-4ba8-9655-07f063033799)
- 지금은 무조건 다 회색 버튼으로 하였는데, 이것도 페이지가 있으면 검정 버튼으로 해야할 것 같습니다.
- 같은 화살표 버튼인데 회색은 icon에, 검정색은 image에 위치해있습니다.