### PR TITLE
[Feature/card-datail-api] 카드 상세 모달 UI 구현 및 할 일 수정 모달 연결 및 초기 데이터 세팅

### DIFF
--- a/src/components/domain/dashboard/Card.tsx
+++ b/src/components/domain/dashboard/Card.tsx
@@ -1,79 +1,131 @@
 import Image from 'next/image'
+import { useState } from 'react'
+
+import { cardsService } from '@/api/services/cardsServices'
 import Tag from '@/components/common/tag/Tag' // 개별 카드
+import Badge from '@/components/common/badge/Badge'
+import TaskCardModal from '../modals/taskcardmodal/TaskCardModal'
+import TaskCardEditModal from '../modals/taskcardeditmodal/TaskCardEditModal'
 import { CardType } from '@/types/api/cards'
 import styles from './card.module.css'
-import Badge from '@/components/common/badge/Badge'
 
 // 내부에서만 사용
 export interface CardProps {
   cardInfo: CardType
+  dashboardId: number
+  columnInfo: { columnId: number; columnTitle: string }
 }
 
-export default function Card({ cardInfo }: CardProps) {
+export default function Card({ cardInfo, dashboardId, columnInfo }: CardProps) {
+  const [isCardDetailModal, setIsCardDetailModal] = useState(false)
+  const [isCardEditModal, setIsCardEditModal] = useState(false)
+
+  const handleCardDetailModal = (state: boolean) => {
+    if (state) setIsCardDetailModal(state)
+    else setIsCardDetailModal(false)
+  }
+
+  const handleCardEditModal = (state: boolean) => {
+    if (state) setIsCardEditModal(state)
+    else setIsCardEditModal(false)
+  }
+
+  const deleteCard = async (cardId: number) => {
+    await cardsService.deleteCards(cardId)
+  }
+
   return (
-    <div className={styles.card}>
-      {/* 이미지: 현재 props로 받은 imageUrl 사용,
+    <>
+      <button
+        className={styles.card}
+        onClick={() => handleCardDetailModal(true)}
+      >
+        {/* 이미지: 현재 props로 받은 imageUrl 사용,
       추후 카드 상세 모달에서 이미지 업로드 API 연동 예정 */}
-      {cardInfo.imageUrl && (
-        <div className={styles.imageWrapper}>
-          <Image
-            src={cardInfo.imageUrl}
-            alt="카드 이미지"
-            className={styles.image}
-            width={500}
-            height={0}
-          />
-        </div>
-      )}
-
-      <div className={styles.content}>
-        {/* 제목: 현재는 title props 그대로 사용,
-        추후 모달에서 수정 가능한 입력 필드로 연동 예정 */}
-        <h4 className="text-lg-medium" style={{ color: 'var(--black-333236)' }}>
-          {cardInfo.title}
-        </h4>
-
-        {/* 태그 리스트: 랜덤 스타일 태그 사용 중,
-        추후 모달에서 태그 추가/삭제 및 색상 재지정 연동 예정*/}
-        <div className={styles.tagList}>
-          {cardInfo.tags.map((tag, index) => (
-            <Tag key={index} label={tag} />
-          ))}
-        </div>
-
-        <div className={styles.meta}>
-          <div className={styles.dateSection}>
+        {cardInfo.imageUrl && (
+          <div className={styles.imageWrapper}>
             <Image
-              src="/assets/icon/calendar.svg"
-              alt="달력 아이콘"
-              width={18}
-              height={18}
-              className={styles.calendarIcon}
+              src={cardInfo.imageUrl}
+              alt="카드 이미지"
+              className={styles.image}
+              width={500}
+              height={0}
             />
-            {/* 날짜는 string으로 받은 값 (ex: '2025-12-31')이며,
-            추후 카드 상세 모달에서 Date 객체로 변환하여 처리할 예정 */}
-            <span>{cardInfo.dueDate}</span>
+          </div>
+        )}
+
+        <div className={styles.content}>
+          {/* 제목: 현재는 title props 그대로 사용,
+        추후 모달에서 수정 가능한 입력 필드로 연동 예정 */}
+          <h4
+            className="text-lg-medium text-start"
+            style={{ color: 'var(--black-333236)' }}
+          >
+            {cardInfo.title}
+          </h4>
+
+          {/* 태그 리스트: 랜덤 스타일 태그 사용 중,
+        추후 모달에서 태그 추가/삭제 및 색상 재지정 연동 예정*/}
+          <div className={styles.tagList}>
+            {cardInfo.tags.map((tag, index) => (
+              <Tag key={index} label={tag} />
+            ))}
           </div>
 
-          <div className={styles.assigneeSection}>
-            {/* 추후 assignee.profileImageUrl로 프로필 이미지 표시 예정
+          <div className={styles.meta}>
+            <div className={styles.dateSection}>
+              <Image
+                src="/assets/icon/calendar.svg"
+                alt="달력 아이콘"
+                width={18}
+                height={18}
+                className={styles.calendarIcon}
+              />
+              {/* 날짜는 string으로 받은 값 (ex: '2025-12-31')이며,
+            추후 카드 상세 모달에서 Date 객체로 변환하여 처리할 예정 */}
+              <span>{cardInfo.dueDate}</span>
+            </div>
+
+            <div className={styles.assigneeSection}>
+              {/* 추후 assignee.profileImageUrl로 프로필 이미지 표시 예정
               현재는 nickname 텍스트만 출력 중 */}
-            {/* assignee에 프로필 이미지가 추가 안된 상태여서 에러가 나는 상황 */}
-            {cardInfo.assignee &&
-              (cardInfo.assignee.profileImageUrl ? (
-                <Image
-                  src={cardInfo.assignee.profileImageUrl}
-                  alt="프로필 이미지"
-                  width={24}
-                  height={24}
-                  className="w-[2.4rem] h-[2.4rem] rounded-full object-cover"
-                />
-              ) : (
-                <Badge nickname={cardInfo.assignee.nickname} />
-              ))}
+              {/* assignee에 프로필 이미지가 추가 안된 상태여서 에러가 나는 상황 */}
+              {cardInfo.assignee &&
+                (cardInfo.assignee.profileImageUrl ? (
+                  <Image
+                    src={cardInfo.assignee.profileImageUrl}
+                    alt="프로필 이미지"
+                    width={24}
+                    height={24}
+                    className="w-[2.4rem] h-[2.4rem] rounded-full object-cover"
+                  />
+                ) : (
+                  <Badge nickname={cardInfo.assignee.nickname} />
+                ))}
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+      </button>
+      {isCardDetailModal && (
+        <TaskCardModal
+          card={cardInfo}
+          dashboardId={dashboardId}
+          columnInfo={columnInfo}
+          onClose={() => handleCardDetailModal(false)}
+          onEdit={() => handleCardEditModal(true)}
+          onDelete={() => {
+            deleteCard(cardInfo.id)
+          }}
+        />
+      )}
+      {isCardEditModal && (
+        <TaskCardEditModal
+          cardInfo={cardInfo}
+          dashboardId={dashboardId}
+          columnInfo={columnInfo}
+          handleCardEditModal={handleCardEditModal}
+        />
+      )}
+    </>
   )
 }

--- a/src/components/domain/dashboard/CardTable.tsx
+++ b/src/components/domain/dashboard/CardTable.tsx
@@ -4,13 +4,24 @@ import { CardType } from '@/types/api/cards'
 
 interface CardTableProps {
   cards: CardType[]
+  dashboardId: number
+  columnInfo: { columnId: number; columnTitle: string }
 }
 
-export default function CardTable({ cards }: CardTableProps) {
+export default function CardTable({
+  cards,
+  dashboardId,
+  columnInfo,
+}: CardTableProps) {
   return (
     <div className="flex flex-col gap-4 px-[2rem]">
       {cards.map((card) => (
-        <Card key={card.id} cardInfo={card} />
+        <Card
+          key={card.id}
+          cardInfo={card}
+          dashboardId={dashboardId}
+          columnInfo={columnInfo}
+        />
       ))}
     </div>
   )

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -10,11 +10,13 @@ import styles from './column.module.css'
 // 내부에서만 사용
 export interface ColumnProps {
   columnInfo: ColumnType
+  dashboardId: number
   handleCardCreateModalOpen: (columnId: number) => void
 }
 
 export default function Column({
   columnInfo,
+  dashboardId,
   handleCardCreateModalOpen,
 }: ColumnProps) {
   const [cards, setCards] = useState<CardType[]>()
@@ -78,7 +80,16 @@ export default function Column({
       </div>
 
       {/* 카드 리스트 */}
-      {cards && <CardTable cards={cards} />}
+      {cards && (
+        <CardTable
+          cards={cards}
+          dashboardId={dashboardId}
+          columnInfo={{
+            columnId: columnInfo.id,
+            columnTitle: columnInfo.title,
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/domain/dashboard/card.module.css
+++ b/src/components/domain/dashboard/card.module.css
@@ -4,6 +4,7 @@
   background-color: white;
   border: 0.1rem solid #d9d9d9;
   overflow: hidden;
+  cursor: pointer;
 }
 
 .imageWrapper {

--- a/src/components/domain/modals/taskcardmodal/taskCardModal.module.css
+++ b/src/components/domain/modals/taskcardmodal/taskCardModal.module.css
@@ -14,7 +14,7 @@
   overflow-y: auto;
   background-color: white;
   border-radius: 1rem; /* 2xl */
-  padding: 3rem 3.8rem 0 1.8rem;
+  padding: 3.2rem 2.5rem;
   position: relative;
 }
 .modaltop {
@@ -26,8 +26,6 @@
 .topRightButtons {
   display: flex;
   position: absolute;
-  width: 8.3rem;
-  height: 3.2rem;
   top: 3rem;
   right: 3.8rem;
   gap: 2.4rem;
@@ -65,26 +63,7 @@
   flex-direction: column;
 }
 
-.assigneespans {
-  font-size: 1.2rem;
-  line-height: 2rem;
-  font-weight: 600;
-  color: var(--black-000000);
-}
-
-.dropdownMenu {
-  z-index: 9999;
-  position: absolute;
-  top: 2.5rem;
-  right: 0;
-  background: white;
-  border: 1px solid #e5e7eb;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-  border-radius: 0.5rem;
-}
-
-.assigneeInfo,
-.dueDateInfo {
+.assigneeInfo {
   color: #4b5563; /* text-gray-600 */
 }
 
@@ -93,31 +72,9 @@
   align-items: center;
 }
 
-.cardStatus {
-  padding-right: 1.2rem;
-  margin-right: 1.2rem;
-  border-right: 0.1rem solid var(--gray-D9D9D9);
-  font-weight: bold;
-  font-size: 1.6rem;
-}
-
 .tagList {
   display: flex;
   gap: 0.8rem;
-}
-
-.cardDescription {
-  padding: 1rem;
-  width: 45rem;
-  height: 7.2rem;
-  font-size: 1.4rem;
-  font-weight: 400;
-  line-height: 2.4rem;
-  letter-spacing: 0;
-  color: #374151; /* text-gray-700 */
-  white-space: pre-wrap;
-  margin-top: 1.6px;
-  margin-bottom: 0.8rem;
 }
 
 .imageWrapper {

--- a/src/components/dropdown/StatusDropdown.tsx
+++ b/src/components/dropdown/StatusDropdown.tsx
@@ -2,28 +2,14 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import Image from 'next/image'
 import styles from './statusDropdown.module.css'
 
-export enum Status {
-  TODO = 'To Do',
-  ON_PROGRESS = 'On Progress',
-  DONE = 'Done',
-  EXAMPLE = 'Example',
-  REVIEW = 'Review',
-}
-
 interface StatusDropdownProps {
-  value: Status
-  onChange: (status: Status) => void
+  statusList: string[]
+  value: string
+  onChange: (status: string) => void
 }
-
-const statusOptions: Status[] = [
-  Status.TODO,
-  Status.ON_PROGRESS,
-  Status.DONE,
-  Status.EXAMPLE,
-  Status.REVIEW,
-]
 
 export default function StatusDropdown({
+  statusList,
   value,
   onChange,
 }: StatusDropdownProps) {
@@ -33,7 +19,7 @@ export default function StatusDropdown({
   const optionRefs = useRef<(HTMLLIElement | null)[]>([])
 
   useEffect(() => {
-    optionRefs.current = new Array(statusOptions.length).fill(null)
+    optionRefs.current = new Array(statusList.length).fill(null)
   }, [])
 
   const assignOptionRef = useCallback(
@@ -43,7 +29,7 @@ export default function StatusDropdown({
     []
   )
 
-  const handleStatusSelect = (status: Status) => {
+  const handleStatusSelect = (status: string) => {
     onChange(status)
     setIsDropdownOpen(false)
   }
@@ -60,19 +46,19 @@ export default function StatusDropdown({
 
       if (event.key === 'ArrowDown') {
         event.preventDefault()
-        setFocusedIndex((prev) => (prev + 1) % statusOptions.length)
+        setFocusedIndex((prev) => (prev + 1) % statusList.length)
       }
 
       if (event.key === 'ArrowUp') {
         event.preventDefault()
         setFocusedIndex(
-          (prev) => (prev - 1 + statusOptions.length) % statusOptions.length
+          (prev) => (prev - 1 + statusList.length) % statusList.length
         )
       }
 
       if (event.key === 'Enter') {
         event.preventDefault()
-        handleStatusSelect(statusOptions[focusedIndex])
+        handleStatusSelect(statusList[focusedIndex])
       }
     }
 
@@ -103,7 +89,7 @@ export default function StatusDropdown({
     }
   }, [focusedIndex, isDropdownOpen])
 
-  const isSelected = (status: Status) => value === status
+  const isSelected = (status: string) => value === status
 
   return (
     <div ref={dropdownContainerRef} className={styles.container}>
@@ -111,7 +97,7 @@ export default function StatusDropdown({
         type="button"
         onClick={() => {
           setIsDropdownOpen((prev) => !prev)
-          setFocusedIndex(statusOptions.findIndex((s) => s === value))
+          setFocusedIndex(statusList.findIndex((s) => s === value))
         }}
         className={`${styles.triggerButton} ${
           isDropdownOpen ? styles.open : styles.closed
@@ -134,7 +120,7 @@ export default function StatusDropdown({
 
       {isDropdownOpen && (
         <ul className={styles.dropdown}>
-          {statusOptions.map((status, index) => (
+          {statusList.map((status, index) => (
             <li
               key={status}
               ref={(el) => assignOptionRef(el, index)}

--- a/src/components/dropdown/UserDropdown.tsx
+++ b/src/components/dropdown/UserDropdown.tsx
@@ -156,8 +156,8 @@ export default function UserDropdown({
             }`}
           >
             <div className={styles.userInfo}>
-              {selectedUser &&
-                (selectedUser.profileImageUrl ? (
+              {selectedUser ? (
+                selectedUser.profileImageUrl ? (
                   <>
                     <Image
                       src={selectedUser.profileImageUrl}
@@ -173,10 +173,12 @@ export default function UserDropdown({
                     <Badge nickname={selectedUser.name} />
                     <span className={styles.userName}>{selectedUser.name}</span>
                   </>
-                ))}
-              <span className={styles.userName}>
-                {selectedUser?.name || '이름을 입력해 주세요'}
-              </span>
+                )
+              ) : (
+                <span className={styles.userName}>
+                  {'이름을 입력해 주세요'}
+                </span>
+              )}
             </div>
             <Image
               src="/assets/image/arrow-down.svg"

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -51,6 +51,7 @@ export default function DashboardPage() {
           <Column
             key={column.id}
             columnInfo={column}
+            dashboardId={dashboardId}
             handleCardCreateModalOpen={handleCardCreateModalOpen}
           />
         ))}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
 type UserData = {
+  id: number
   nickname: string
   email: string
   profileImageUrl?: string


### PR DESCRIPTION
## 📌 PR 개요
카드 상세 모달 UI 구현 및 할 일 수정 모달 연결 및 초기 데이터 세팅

## 🏃‍♂️‍➡️ 요구사항
### 대시보드 상세 페이지 구현하기(/dashboard/{dashboardid}) 
- [x] 생성된 할 일 카드를 클릭하면 해당 카드 상세 모달이 나타나도록 하세요.

### 할 일 카드 상세 모달 구현하기(/dashboard/{dashboardid}) - 할 일 카드 상세 모달 구현하기
- [x]  만들어진 카드 정보를 보여주도록 하세요.
- [x]  댓글 input에 값을 입력하고 '입력' 버튼을 클릭하면 댓글이 남겨지도록 하세요.
- [x]  내가 남긴 댓글에 '수정' 버튼을 클릭하면 내용을 수정할 수 있도록 하세요.
- [x]  내가 남긴 댓글에 '삭제' 버튼을 클릭하면 내용을 삭제할 수 있도록 하세요.
- [x]  오른쪽 상단 케밥을 클릭하면 드롭다운으로 수정하기, 삭제하기를 고를 수 있도록 하세요.
- [x]  '수정하기' 버튼을 클릭하면 할 일 수정 모달이 나타나도록 하세요.
- [x]  '삭제하기' 버튼을 클릭하면 해당 카드가 삭제되도록 하세요.


## 🔥 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 카드 클릭 시에 카드 상세 모달 띄우기 및 동일한 내용으로 나오게
- 전체적인 카드 상세 모달 UI 유사하게 구현
- 오른쪽 상단 케밥 클릭 시, 드롭다운
- 드롭다운에서 수정하기 버튼 클릭 시 할 일 수정 모달
- 드롭다운에서 삭제하기 버튼 클릭 시 카드 삭제

## 📷 스크린샷
![image (5)](https://github.com/user-attachments/assets/9ba2aade-af24-4c9f-a6ee-81b4de6bad81)
이미지가 들어간 카드 상세 모달
![image (6)](https://github.com/user-attachments/assets/3f90f1cd-bb10-4128-9caf-7d738a2786dc)
카드 상세 모달의 드롭다운
![image (7)](https://github.com/user-attachments/assets/1dc41004-b7d7-4963-a989-758d4f6ca397)
필수 값들만 들어간 카드 상세 모달


## 🚧 관련 이슈
SCRUM - 34, 35, 36, 121

## 💡 추가 정보
- 카드 상세 모달 UI 전체적인 체킹과 구현 필요
- 댓글 무한스크롤과 댓글 input 비어있을 시 입력 버튼 비활성화 필요
- 댓글 삭제 시, 경고 메시지 없이 바로 삭제됨
- 오른쪽 상단 케밥 드롭다운에서 삭제하기 클릭 시, 새로고침을 해야 반영하는 로직으로 수정 필요
- 태그 색상 유지하도록 하는 로직 필요