### PR TITLE
[Feature/homenav] HomeNavbar 프로필 이미지 추가 및 오류 수정

### DIFF
--- a/src/components/layout/gnb/HomeNavBar.tsx
+++ b/src/components/layout/gnb/HomeNavBar.tsx
@@ -25,9 +25,7 @@ export default function HomeNavBar({
 }: HomeNavBarProps) {
   const { userData } = useAuthStore()
   const { members } = useDashboardMembers()
-  console.log(dashboardId)
 
-  // 제목 결정
   const getTitle = () => {
     switch (pageType) {
       case 'mydashboard':
@@ -40,20 +38,11 @@ export default function HomeNavBar({
         return ''
     }
   }
-
-  // 왕관 아이콘 표시 여부
+  const filteredMembers = Array.isArray(members)
+    ? members.filter((member) => member.email !== userData?.email)
+    : []
   const showCrown = pageType === 'mydashboard' && hasCrown
-
-  // 초대 및 관리 버튼 등 표시 여부
   const showDashboardControls = pageType !== 'mydashboard'
-  console.log(members)
-  // 멤버 정보 텍스트
-  const memberInfo =
-    pageType === 'dashboard'
-      ? Array.isArray(members) && members.length > 0
-        ? `${members.length} 명`
-        : '멤버 없음'
-      : ''
 
   return (
     <div className={clsx(styles.flex_center_space_between, styles.nav_wrapper)}>
@@ -74,7 +63,6 @@ export default function HomeNavBar({
 
       {/* 오른쪽 영역 */}
       <div className={clsx(styles.flex_center_space_between)}>
-        {/* 설정 및 초대 버튼 등dd */}
         {showDashboardControls && (
           <div
             className={clsx(
@@ -123,8 +111,8 @@ export default function HomeNavBar({
                   <Image
                     src="/assets/icon/add-box-gray.svg"
                     alt="초대 아이콘"
-                    width={20}
-                    height={20}
+                    width={38}
+                    height={38}
                     className={styles.icon}
                   />
                 }
@@ -133,7 +121,36 @@ export default function HomeNavBar({
                 초대하기
               </ButtonDashboard>
             </div>
-            <div className={styles.name_mark}>{memberInfo}</div>
+
+            {/* 초대 멤버 프로필 */}
+            <div className={styles.invited_members_wrapper}>
+              {filteredMembers.slice(0, 4).map((member) => (
+                <div key={member.email} className={styles.invited_profile}>
+                  {member.profileImageUrl ? (
+                    <Image
+                      src={member.profileImageUrl}
+                      alt={member.nickname}
+                      width={296}
+                      height={296}
+                      style={{
+                        width: '4rem',
+                        height: '4rem',
+                        objectFit: 'cover',
+                        objectPosition: 'center',
+                        borderRadius: '50%',
+                        display: 'block',
+                      }}
+                    />
+                  ) : (
+                    <Badge nickname={member.nickname} />
+                  )}
+                </div>
+              ))}
+
+              {Array.isArray(members) && members.length > 4 && (
+                <div className={styles.extra_count}>+{members.length - 4}</div>
+              )}
+            </div>
           </div>
         )}
 
@@ -146,18 +163,25 @@ export default function HomeNavBar({
               <Image
                 src={userData.profileImageUrl}
                 alt="Profile Image"
-                width={40}
-                height={40}
+                width={296}
+                height={296}
                 style={{
+                  width: '4rem',
+                  height: '4rem',
                   objectFit: 'cover',
                   objectPosition: 'center',
+                  borderRadius: '50%',
+                  display: 'block',
                 }}
               />
             ) : (
               <Badge nickname={userData ? userData.nickname : ''} />
             )}
           </div>
-          <div className={`${styles.name} text-lg-medium`}>
+          <div
+            className={`${styles.name} text-lg-medium`}
+            style={{ marginLeft: '1.2rem' }}
+          >
             {userData?.nickname}
           </div>
         </div>

--- a/src/components/layout/gnb/homenavbar.module.css
+++ b/src/components/layout/gnb/homenavbar.module.css
@@ -34,16 +34,35 @@
   width: max-content;
 }
 .profile_image {
-  width: 4rem;
-  height: 4rem;
   border-radius: 50%;
   overflow: hidden;
 }
-.name {
+.me {
   padding-left: 1.3rem;
   cursor: pointer;
 }
-.icon {
+.invited_members_wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.invited_profile:not(:first-child) {
+  margin-left: -1rem;
+}
+
+.extra_count {
+  width: 3.8rem;
+  height: 3.8rem;
+  border-radius: 50%;
+  background-color: var(--gray-e4e4e7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.6rem;
+  font-weight: 500;
+  color: var(--gray-787486);
+  border: 0.2rem solid #fff;
+  margin-left: -0.6rem;
 }
 /*태블릿*/
 @media (max-width: 1023px) {

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -262,15 +262,15 @@ export default function MyPage() {
                   <label
                     htmlFor="avatarUpload"
                     aria-label="프로필 이미지 업로드"
-                    className="w-[18.2rem] h-[18.2rem] flex items-center justify-center bg-[var(--gray-EEEEEE)] text-[3.2rem] text-[var(--violet-5534DhA)] border border-[var(--gray-D9D9D9)] rounded-[1.6rem] cursor-pointer transition-colors hover:bg-[var(--gray-FAFAFA)] hover:border-[var(--violet-5534DhA)] relative"
+                    className="w-[18.2rem] h-[18.2rem] flex items-center justify-center bg-[var(--gray-EEEEEE)] text-[3.2rem] text-[var(--violet-5534DhA)] border border-[var(--gray-D9D9D9)] rounded-[1.6rem] cursor-pointer transition-colors hover:bg-[var(--gray-FAFAFA)] hover:border-[var(--violet-5534DhA)]"
                   >
                     {previewImage ? (
                       <Image
                         src={previewImage}
                         alt="프로필 미리보기"
                         className="object-cover w-full h-full rounded-[1.6rem]"
-                        width={76}
-                        height={76}
+                        width={296}
+                        height={296}
                       />
                     ) : (
                       '+'


### PR DESCRIPTION
## 📌 PR 개요
Nav바 프로필 이미지 추가 구현과 원형이 찌그러지거나 반만 보이는 오류를 수정하였음

## 🏃‍♂️‍➡️ 요구사항
- [x] 초대 받은 멤버 프로필이나 뱃지 구현
- [x] 프로필 이미지 짤림 -> 프로필 이미지 정상으로 수정

## 🔥 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📷 스크린샷 (선택)
### homeNav바의 프로필 원이 짤림 현상
![image](https://github.com/user-attachments/assets/1b064159-8ad7-4918-901a-64a999459a17)
### 원인: 프로필 이미지 높이가 작고, overflow: hidden을 주지 않아 이미지가 튀어나오는 현상이 발생

### 수정 후
![프로필 저장](https://github.com/user-attachments/assets/a03919ac-6721-4765-b234-99bf307ef144)

## 🚧 관련 이슈
<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보
📌 이미지 화질을 높이기 위해 실제 렌더링 크기보다 큰 width={296} height={296} 값을 사용했습니다. 이를 통해 고해상도 디스플레이에서도 선명한 이미지를 유지할 수 있습니다.
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->