### PR TITLE
[Fix/card] 전반적인 카드 관련 기능 수정 (카드 담당자, 카드 생성, 댓글 input, 댓글 UI)

### DIFF
--- a/src/components/domain/dashboard/Card.tsx
+++ b/src/components/domain/dashboard/Card.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import { useState } from 'react'
+import { SetStateAction, useState } from 'react'
 
 import { cardsService } from '@/api/services/cardsServices'
 import Tag from '@/components/common/tag/Tag' // 개별 카드
@@ -14,9 +14,15 @@ export interface CardProps {
   cardInfo: CardType
   dashboardId: number
   columnInfo: { columnId: number; columnTitle: string }
+  setRefreshTrigger: React.Dispatch<SetStateAction<number>>
 }
 
-export default function Card({ cardInfo, dashboardId, columnInfo }: CardProps) {
+export default function Card({
+  cardInfo,
+  dashboardId,
+  columnInfo,
+  setRefreshTrigger,
+}: CardProps) {
   const [isCardDetailModal, setIsCardDetailModal] = useState(false)
   const [isCardEditModal, setIsCardEditModal] = useState(false)
 
@@ -32,6 +38,8 @@ export default function Card({ cardInfo, dashboardId, columnInfo }: CardProps) {
 
   const deleteCard = async (cardId: number) => {
     await cardsService.deleteCards(cardId)
+    setRefreshTrigger((prev) => prev + 1)
+    setIsCardDetailModal(false)
   }
 
   return (

--- a/src/components/domain/dashboard/CardTable.tsx
+++ b/src/components/domain/dashboard/CardTable.tsx
@@ -1,17 +1,20 @@
 // 카드 리스트들
 import Card from '@/components/domain/dashboard/Card'
 import { CardType } from '@/types/api/cards'
+import { SetStateAction } from 'react'
 
 interface CardTableProps {
   cards: CardType[]
   dashboardId: number
   columnInfo: { columnId: number; columnTitle: string }
+  setRefreshTrigger: React.Dispatch<SetStateAction<number>>
 }
 
 export default function CardTable({
   cards,
   dashboardId,
   columnInfo,
+  setRefreshTrigger,
 }: CardTableProps) {
   return (
     <div className="flex flex-col gap-4 px-[2rem]">
@@ -21,6 +24,7 @@ export default function CardTable({
           cardInfo={card}
           dashboardId={dashboardId}
           columnInfo={columnInfo}
+          setRefreshTrigger={setRefreshTrigger}
         />
       ))}
     </div>

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -11,6 +11,7 @@ import styles from './column.module.css'
 export interface ColumnProps {
   columnInfo: ColumnType
   dashboardId: number
+  refreshTrigger: number
   handleCardCreateModalOpen: (columnId: number) => void
   handleColumnEditModal: (state: boolean) => void
   handleColumnOptionClick: (columnInfo: ColumnType) => void
@@ -19,6 +20,7 @@ export interface ColumnProps {
 export default function Column({
   columnInfo,
   dashboardId,
+  refreshTrigger,
   handleCardCreateModalOpen,
   handleColumnEditModal,
   handleColumnOptionClick,
@@ -31,7 +33,7 @@ export default function Column({
 
   useEffect(() => {
     getCards()
-  }, [])
+  }, [refreshTrigger])
 
   return (
     <>

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { SetStateAction, useEffect, useState } from 'react'
 import Image from 'next/image'
 import CardTable from '@/components/domain/dashboard/CardTable'
 import ButtonDashboard from '@/components/common/commonbutton/ButtonDashboard'
@@ -12,6 +12,7 @@ export interface ColumnProps {
   columnInfo: ColumnType
   dashboardId: number
   refreshTrigger: number
+  setRefreshTrigger: React.Dispatch<SetStateAction<number>>
   handleCardCreateModalOpen: (columnId: number) => void
   handleColumnEditModal: (state: boolean) => void
   handleColumnOptionClick: (columnInfo: ColumnType) => void
@@ -21,6 +22,7 @@ export default function Column({
   columnInfo,
   dashboardId,
   refreshTrigger,
+  setRefreshTrigger,
   handleCardCreateModalOpen,
   handleColumnEditModal,
   handleColumnOptionClick,
@@ -100,6 +102,7 @@ export default function Column({
               columnId: columnInfo.id,
               columnTitle: columnInfo.title,
             }}
+            setRefreshTrigger={setRefreshTrigger}
           />
         )}
       </div>

--- a/src/components/domain/modals/taskcardcreatemodal/TaskCardCreateModal.tsx
+++ b/src/components/domain/modals/taskcardcreatemodal/TaskCardCreateModal.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import Input from '@/components/common/commoninput/CommonInput'
 import Tag from '@/components/common/tag/Tag'
 import type { TagColor } from '@/types/common/tag'
-import { useRef, useState } from 'react'
+import { SetStateAction, useRef, useState } from 'react'
 import UserDropdown from '@/components/dropdown/UserDropdown'
 import { cardsService } from '@/api/services/cardsServices'
 import { CreateCardBody } from '@/types/api/cards'
@@ -30,12 +30,14 @@ interface TaskCardCreateModalProps {
   dashboardId: number
   columnId: number
   handleCardCreateModalClose: () => void
+  setRefreshTrigger: React.Dispatch<SetStateAction<number>>
 }
 
 export default function TaskCardCreateModal({
   dashboardId,
   columnId,
   handleCardCreateModalClose,
+  setRefreshTrigger,
 }: TaskCardCreateModalProps) {
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
@@ -86,12 +88,16 @@ export default function TaskCardCreateModal({
 
   const handleSubmitForm = async () => {
     const bodyData: CreateCardBody = {
-      assigneeUserId: assignee,
       dashboardId: dashboardId,
       columnId: columnId,
       title: title,
       description: description,
       tags: tags.map((tag) => tag.label), // 태그 배열 요청 바디에 넣을 수 있는 형태로 변경
+    }
+
+    // 담당자가 있으면 담당자 추가
+    if (assignee != -1) {
+      bodyData.assigneeUserId = assignee
     }
 
     // 이미지가 있으면 이미지 먼저 생성 요청
@@ -116,7 +122,9 @@ export default function TaskCardCreateModal({
     // 서버로 요청
     await cardsService.postCards(bodyData)
 
-    window.location.reload()
+    setRefreshTrigger((prev) => prev + 1)
+
+    handleCardCreateModalClose()
   }
 
   const handleImageClick = () => {

--- a/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
+++ b/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
@@ -50,7 +50,6 @@ export default function TaskCardEditModal({
   const [title, setTitle] = useState(cardInfo.title)
   // const [selectedUser, setSelectedUser] = useState<User>()
   const [assignee, setAssignee] = useState(-1)
-  console.log(assignee)
   const [description, setDescription] = useState(cardInfo.description)
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
   const [inputValue, setInputValue] = useState('')

--- a/src/components/domain/modals/taskcardmodal/TaskCardModal.tsx
+++ b/src/components/domain/modals/taskcardmodal/TaskCardModal.tsx
@@ -226,7 +226,9 @@ export default function TaskCardModal({
             </div>
           </div>
 
-          <p className={`p-[1rem] w-[45rem] mt-[1.6rem] text-md-regular`}>
+          <p
+            className={`p-[1rem] w-[45rem] mt-[1.6rem] text-md-regular break-all`}
+          >
             {card.description}
           </p>
 
@@ -244,14 +246,18 @@ export default function TaskCardModal({
               <textarea
                 value={inputComment}
                 onChange={(e) => setInputComment(e.target.value)}
-                placeholder="댓글을 입력하세요"
-                className={`${styles.textareainput} resize-none`}
+                placeholder="댓글 작성하기"
+                className={`${styles.textareainput} text-md-regular resize-none`}
               />
               <div className={styles.commentinputbutton}>
                 <button
+                  className={`w-[8.3rem] h-[3.2rem] border border-[#D9D9D9] rounded-[0.4rem] ${
+                    inputComment
+                      ? 'text-[#5534DA] cursor-pointer'
+                      : 'text-[#D9D9D9]'
+                  } text-xs-medium`}
                   onClick={addComment}
                   disabled={!inputComment.trim()}
-                  className={styles.commentbutton}
                 >
                   입력
                 </button>
@@ -259,32 +265,61 @@ export default function TaskCardModal({
             </div>
           </div>
 
-          <div ref={commentContainerRef} className={styles.commentList}>
+          <div
+            ref={commentContainerRef}
+            className="flex flex-col gap-[2.4rem] mt-[2.4rem]"
+          >
             {comments.map((comment) => (
-              <div key={comment.id} className={styles.commentCard}>
-                <div className={styles.commentMeta}>
-                  {formatDate(comment.createdAt)}
+              <div key={comment.id} className="flex w-[45rem] gap-[1rem]">
+                <div className="w-[3.4rem] h-[3.4rem]">
+                  {comment.author.profileImageUrl ? (
+                    <Image
+                      className="w-[3.4rem] h-[3.4rem] object-cover"
+                      src={comment.author.profileImageUrl}
+                      width={50}
+                      height={50}
+                      alt="프로필 이미지"
+                    />
+                  ) : (
+                    <Badge nickname={comment.author.nickname} />
+                  )}
                 </div>
-                <div className={styles.commentContent}>{comment.content}</div>
-                {comment.author.id === userData.id && (
-                  <div className={styles.commentButtons}>
-                    <button
-                      onClick={() => {
-                        const newContent = prompt('댓글 수정', comment.content)
-                        if (newContent !== null)
-                          editComment(comment.id, newContent)
-                      }}
-                    >
-                      수정
-                    </button>
-                    <button
-                      onClick={() => deleteComment(comment.id)}
-                      className="text-red-500"
-                    >
-                      삭제
-                    </button>
+                <div className="w-[39rem]">
+                  <div className="flex items-center gap-[0.8rem]">
+                    <div className="text-[#333236] text-lg-semibold">
+                      {comment.author.nickname}
+                    </div>
+                    <div className="text-[#9FA6B2] text-xs-regular">
+                      {formatDate(comment.createdAt)}
+                    </div>
                   </div>
-                )}
+                  <div className="text-[#333236] break-all">
+                    {comment.content}
+                  </div>
+                  {comment.author.id === userData.id && (
+                    <div className="flex items-center gap-[1.2rem] mt-[1rem] text-[#9FA6B2] text-xs-regular">
+                      <button
+                        className="border-b border-[#9FA6B2] cursor-pointer"
+                        onClick={() => {
+                          const newContent = prompt(
+                            '댓글 수정',
+                            comment.content
+                          )
+                          if (newContent !== null)
+                            editComment(comment.id, newContent)
+                        }}
+                      >
+                        수정
+                      </button>
+                      <button
+                        className="border-b border-[#9FA6B2] cursor-pointer"
+                        onClick={() => deleteComment(comment.id)}
+                      >
+                        삭제
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
             ))}
             <div ref={observerTargetRef} style={{ height: '0.1rem' }} />

--- a/src/components/domain/modals/taskcardmodal/taskCardModal.module.css
+++ b/src/components/domain/modals/taskcardmodal/taskCardModal.module.css
@@ -14,7 +14,7 @@
   overflow-y: auto;
   background-color: white;
   border-radius: 1rem; /* 2xl */
-  padding: 3.2rem 2.5rem;
+  padding: 3.2rem 2.5rem 0 2.5rem;
   position: relative;
 }
 .modaltop {
@@ -124,25 +124,6 @@
   right: 1.2rem;
   bottom: 1.2rem;
 }
-.commentbutton {
-  font-size: 1.2rem;
-  font-weight: 500;
-  line-height: 1.8rem;
-  width: 8.3rem;
-  height: 3.2rem;
-  border: 0.1rem solid var(--gray-D9D9D9);
-  border-radius: 0.4rem;
-  color: var(--violet-5534DhA);
-}
-
-.commentList {
-  margin-top: 1rem;
-  max-height: 30rem;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
 
 .commentCard {
   padding: 1rem;
@@ -155,10 +136,6 @@
 
 .commentMeta {
   font-size: 0.875rem;
-  color: var(--gray-9FA6B2);
-}
-
-.commentContent {
   color: var(--gray-9FA6B2);
 }
 

--- a/src/components/layout/sidebar/sidebar.module.css
+++ b/src/components/layout/sidebar/sidebar.module.css
@@ -12,6 +12,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  z-index: 5;
 }
 .navbar {
   display: flex;

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -19,6 +19,7 @@ export default function DashboardPage() {
   const [triggeredColumn, setTriggeredColumn] = useState<ColumnType | null>(
     null
   )
+  const [refreshTrigger, setRefreshTrigger] = useState<number>(0)
 
   const [isCardCreateModalOpen, setIsCardCreateModalOpen] = useState(false)
   const [isColumnCreateModal, setIsColumnCreateModal] = useState(false)
@@ -137,6 +138,7 @@ export default function DashboardPage() {
             key={column.id}
             columnInfo={column}
             dashboardId={dashboardId}
+            refreshTrigger={refreshTrigger}
             handleCardCreateModalOpen={handleCardCreateModalOpen}
             handleColumnEditModal={handleColumnEditModal}
             handleColumnOptionClick={handleColumnOptionClick}
@@ -173,6 +175,7 @@ export default function DashboardPage() {
           dashboardId={dashboardId}
           columnId={selectedColumnId}
           handleCardCreateModalClose={handleCardCreateModalClose}
+          setRefreshTrigger={setRefreshTrigger}
         />
       )}
       {isColumnCreateModal && (

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -139,6 +139,7 @@ export default function DashboardPage() {
             columnInfo={column}
             dashboardId={dashboardId}
             refreshTrigger={refreshTrigger}
+            setRefreshTrigger={setRefreshTrigger}
             handleCardCreateModalOpen={handleCardCreateModalOpen}
             handleColumnEditModal={handleColumnEditModal}
             handleColumnOptionClick={handleColumnOptionClick}


### PR DESCRIPTION
## 📌 PR 개요
전반적인 카드 관련 기능 수정 (카드 담당자, 카드 생성, 댓글 input, 댓글 UI)

## 🏃‍♂️‍➡️ 요구사항
### 할 일 카드 상세 모달 구현하기(/dashboard/{dashboardid}) - 할 일 카드 상세 모달 구현하기
- [x]  댓글 input에 값이 비어있으면 '입력' 버튼이 비활성화되도록 하세요.

## 🔥 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 담당자 없을 때에도 카드 생성되게 수정
- 카드 생성 시 새로고침 없이도 반영되게 로직 수정
- 댓글 input이 없을 때에는 입력 버튼 비활성화
- 간단한 댓글 UI 비슷하게 구현
- 태그 z-index 값 수정

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/fdf5419d-d4e3-4285-89c0-7bc568bdfcb7)
입력 버튼 비활성화 및 댓글 UI 간단한 구현

## 🚧 관련 이슈
SCRUM - 29, 32, 33

## 💡 추가 정보
- 댓글 input 비활성화에 대한 피그마 디자인이 없어서 비활성일 때에는 '입력' 글씨를 회색 처리
- 댓글 UI 전반적인 수정 필요
- 카드 상세 모달에서 오른쪽 부분의 박스는 sticky 주면 좋을 것