### PR TITLE
[Feature/card-edit-modal] 할 일 수정 모달 기능 구현(수정, input 기본값 유지, 수정 내용 반영)

### DIFF
--- a/src/components/domain/dashboard/Card.tsx
+++ b/src/components/domain/dashboard/Card.tsx
@@ -8,12 +8,13 @@ import TaskCardModal from '../modals/taskcardmodal/TaskCardModal'
 import TaskCardEditModal from '../modals/taskcardeditmodal/TaskCardEditModal'
 import { CardType } from '@/types/api/cards'
 import styles from './card.module.css'
+import { ColumnType } from '@/types/api/columns'
 
 // 내부에서만 사용
 export interface CardProps {
   cardInfo: CardType
   dashboardId: number
-  columnInfo: { columnId: number; columnTitle: string }
+  columnInfo: ColumnType
   setRefreshTrigger: React.Dispatch<SetStateAction<number>>
 }
 
@@ -132,6 +133,7 @@ export default function Card({
           dashboardId={dashboardId}
           columnInfo={columnInfo}
           handleCardEditModal={handleCardEditModal}
+          setRefreshTrigger={setRefreshTrigger}
         />
       )}
     </>

--- a/src/components/domain/dashboard/CardTable.tsx
+++ b/src/components/domain/dashboard/CardTable.tsx
@@ -1,12 +1,13 @@
 // 카드 리스트들
 import Card from '@/components/domain/dashboard/Card'
 import { CardType } from '@/types/api/cards'
+import { ColumnType } from '@/types/api/columns'
 import { SetStateAction } from 'react'
 
 interface CardTableProps {
   cards: CardType[]
   dashboardId: number
-  columnInfo: { columnId: number; columnTitle: string }
+  columnInfo: ColumnType
   setRefreshTrigger: React.Dispatch<SetStateAction<number>>
 }
 

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -98,10 +98,7 @@ export default function Column({
           <CardTable
             cards={cards}
             dashboardId={dashboardId}
-            columnInfo={{
-              columnId: columnInfo.id,
-              columnTitle: columnInfo.title,
-            }}
+            columnInfo={columnInfo}
             setRefreshTrigger={setRefreshTrigger}
           />
         )}

--- a/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
+++ b/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
@@ -252,6 +252,8 @@ export default function TaskCardEditModal({
                   setTitle(e.target.value)
                   if (e.target.value != cardInfo.title) setIsDisable(false)
                   else setIsDisable(true)
+
+                  if (!e.target.value) setIsDisable(true)
                 }}
                 placeholder="제목을 입력해 주세요"
                 height="5rem"
@@ -275,6 +277,8 @@ export default function TaskCardEditModal({
                     if (e.target.value != cardInfo.description)
                       setIsDisable(false)
                     else setIsDisable(true)
+
+                    if (!e.target.value) setIsDisable(true)
                   }}
                   placeholder="설명을 입력해 주세요"
                   className="w-full px-[1.6rem] pt-[1.5rem] pb-[8.5rem] bg-[var(--white-FFFFFF)] text-lg-regular text-[var(--black-333236)] placeholder-[var(--gray-9FA6B2)] outline-none resize-none rounded-lg"

--- a/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
+++ b/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { SetStateAction, useEffect, useRef, useState } from 'react'
 import Image from 'next/image'
 import DatePicker from 'react-datepicker'
 import 'react-datepicker/dist/react-datepicker.css'
@@ -10,10 +10,12 @@ import Tag from '@/components/common/tag/Tag'
 import UserDropdown from '@/components/dropdown/UserDropdown'
 import StatusDropdown from '@/components/dropdown/StatusDropdown'
 import type { TagColor } from '@/types/common/tag'
-import { CardType } from '@/types/api/cards'
+import { CardType, UpdateCardBody } from '@/types/api/cards'
 import { ColumnType } from '@/types/api/columns'
 import { columnsService } from '@/api/services/columnsServices'
 import { useDashboardMembers } from '@/stores/dashboardMembers'
+import { cardsService } from '@/api/services/cardsServices'
+import AnimatedModalContainer from '@/components/common/animatedmodalcontainer/AnimatedModalContainer'
 
 const TAG_COLORS: TagColor[] = [
   'tag-orange',
@@ -36,8 +38,9 @@ function getRandomTagColor(): TagColor {
 interface TaskCardEditModalProps {
   cardInfo: CardType
   dashboardId: number
-  columnInfo: { columnId: number; columnTitle: string }
+  columnInfo: ColumnType
   handleCardEditModal: (status: boolean) => void
+  setRefreshTrigger: React.Dispatch<SetStateAction<number>>
 }
 
 export default function TaskCardEditModal({
@@ -45,13 +48,16 @@ export default function TaskCardEditModal({
   dashboardId,
   columnInfo,
   handleCardEditModal,
+  setRefreshTrigger,
 }: TaskCardEditModalProps) {
-  const [statusValue, setStatusValue] = useState<string>(columnInfo.columnTitle)
+  const [selectedColumn, setSelectedColumn] = useState<ColumnType>(columnInfo)
   const [title, setTitle] = useState(cardInfo.title)
-  // const [selectedUser, setSelectedUser] = useState<User>()
   const [assignee, setAssignee] = useState(-1)
   const [description, setDescription] = useState(cardInfo.description)
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+  const [selectedDate, setSelectedDate] = useState<Date | null>(
+    new Date(cardInfo.dueDate)
+  )
+
   const [inputValue, setInputValue] = useState('')
   const [columns, setColumns] = useState<ColumnType[]>([])
   const [tags, setTags] = useState<{ label: string; color: TagColor }[]>(
@@ -60,8 +66,13 @@ export default function TaskCardEditModal({
   const [availableColors, setAvailableColors] = useState<TagColor[]>([
     ...TAG_COLORS,
   ])
-  const [preview, setPreview] = useState<string | null>(null)
+
+  const [preview, setPreview] = useState<string | null>(cardInfo.imageUrl)
+  const [imgFile, setImgFile] = useState<File | undefined>()
   const inputRef = useRef<HTMLInputElement>(null)
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [IsDisable, setIsDisable] = useState(true)
 
   const dashboardMembers = useDashboardMembers((state) => state.members)
   const users = dashboardMembers.map((user) => ({
@@ -79,15 +90,17 @@ export default function TaskCardEditModal({
     (typeof users)[0] | undefined
   >(currentUser)
 
-  const handleStatusSelect = (value: string) => {
-    setStatusValue(value)
+  const handleStatusSelect = (column: ColumnType) => {
+    setSelectedColumn(column)
   }
 
   const handleImageClick = () => inputRef.current?.click()
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsDisable(false)
     const file = e.target.files?.[0]
     if (file) {
+      setImgFile(file)
       const reader = new FileReader()
       reader.onloadend = () => setPreview(reader.result as string)
       reader.readAsDataURL(file)
@@ -96,6 +109,7 @@ export default function TaskCardEditModal({
 
   const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && inputValue.trim() !== '') {
+      setIsDisable(false)
       const randomIndex = Math.floor(Math.random() * availableColors.length)
       const selectedColor = availableColors[randomIndex]
       setTags([...tags, { label: inputValue.trim(), color: selectedColor }])
@@ -114,193 +128,293 @@ export default function TaskCardEditModal({
     setColumns(columnsData.data)
   }
 
+  const handleSubmitForm = async () => {
+    setIsLoading(true)
+    try {
+      const bodyData: UpdateCardBody = {
+        columnId: selectedColumn.id,
+        title: title,
+        description: description,
+        tags: tags.map((tag) => tag.label), // 태그 배열 요청 바디에 넣을 수 있는 형태로 변경
+      }
+
+      // 담당자가 있으면 담당자 추가
+      if (assignee != -1) {
+        bodyData.assigneeUserId = assignee
+      }
+
+      // 이미지가 있으면 이미지 먼저 생성 요청
+      if (imgFile) {
+        // 이미지가 있다면 columnService.postColumnsImage 메서드로 이미지 생성 요청부터.
+        const postImage = await columnsService.postColumnsImage(
+          columnInfo.id,
+          imgFile
+        )
+        bodyData.imageUrl = postImage.imageUrl
+      }
+
+      // 날짜 데이터 파싱
+      if (selectedDate) {
+        const date = selectedDate // Date 타입
+        const parseDate = `${date.getFullYear()}-${String(
+          date.getMonth() + 1
+        ).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(
+          date.getHours()
+        ).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
+
+        bodyData.dueDate = parseDate
+      }
+
+      // 서버로 요청
+      await cardsService.putCards(cardInfo.id, bodyData)
+
+      setRefreshTrigger((prev) => prev + 1)
+
+      handleCardEditModal(false)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   useEffect(() => {
     getColumns()
   }, [dashboardId])
 
   return (
-    <div className="fixed inset-0 z-50 bg-[rgba(0,0,0,0.7)] flex justify-center items-center">
-      <div className="w-[58.4rem] bg-[var(--white-FFFFFF)] rounded-2xl overflow-auto">
-        <div className="p-[3.2rem]">
-          <h2 className="pb-[3.2rem] text-2xl-bold text-[var(--black-333236)]">
-            할 일 수정
-          </h2>
+    <AnimatedModalContainer isLoading={isLoading}>
+      <div className="fixed inset-0 z-50 bg-[rgba(0,0,0,0.7)] flex justify-center items-center">
+        <div className="w-[58.4rem] bg-[var(--white-FFFFFF)] rounded-2xl overflow-auto">
+          <div className="p-[3.2rem]">
+            <h2 className="pb-[3.2rem] text-2xl-bold text-[var(--black-333236)]">
+              할 일 수정
+            </h2>
 
-          {/* 상태 + 담당자 */}
-          <div className="flex w-full gap-[3.2rem]">
-            {/* 상태 */}
-            <div className="flex flex-col pb-[3.2rem] gap-[0.8rem] w-[21.7rem]">
-              <label className="text-2lg-medium text-[var(--black-333236)]">
-                상태
-              </label>
-              {columns && columns.length ? (
-                <StatusDropdown
-                  statusList={columns.map((column) => column.title)}
-                  value={statusValue}
-                  onChange={handleStatusSelect}
-                />
-              ) : null}
-            </div>
+            {/* 상태 + 담당자 */}
+            <div className="flex w-full gap-[3.2rem]">
+              {/* 상태 */}
+              <div className="flex flex-col pb-[3.2rem] gap-[0.8rem] w-[21.7rem]">
+                <label className="text-2lg-medium text-[var(--black-333236)]">
+                  상태
+                </label>
+                {columns && columns.length ? (
+                  <StatusDropdown
+                    columnList={columns}
+                    value={selectedColumn}
+                    onChange={(column) => {
+                      handleStatusSelect(column)
+                      if (column.id !== columnInfo.id) setIsDisable(false)
+                      else setIsDisable(true)
+                    }}
+                  />
+                ) : null}
+              </div>
 
-            {/* 담당자 */}
-            <div className="flex flex-col pb-[3.2rem] gap-[0.8rem] w-[21.7rem]">
-              <label className="text-2lg-medium text-[var(--black-333236)]">
-                담당자
-              </label>
+              {/* 담당자 */}
+              <div className="flex flex-col pb-[3.2rem] gap-[0.8rem] w-[21.7rem]">
+                <label className="text-2lg-medium text-[var(--black-333236)]">
+                  담당자
+                </label>
 
-              <UserDropdown
-                users={users}
-                selectedUser={selectedUser}
-                onChange={setSelectedUser}
-                mode="select"
-                setAssignee={setAssignee}
-              />
-            </div>
-          </div>
-
-          {/* 제목 */}
-          <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
-            <label className="text-2lg-medium text-[var(--black-333236)] flex items-center gap-[2px]">
-              제목
-              <span className="text-[var(--violet-5534DhA)] text-lg-regular">
-                *
-              </span>
-            </label>
-            <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="제목을 입력해 주세요"
-              height="5rem"
-              padding="1.2rem 1.6rem"
-            />
-          </div>
-
-          {/* 설명 */}
-          <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
-            <label className="text-2lg-medium text-[var(--black-333236)] flex items-center gap-[2px]">
-              설명
-              <span className="text-[var(--violet-5534DhA)] text-lg-regular">
-                *
-              </span>
-            </label>
-            <div className="w-full border border-[var(--gray-D9D9D9)] rounded-lg focus-within:border-[var(--violet-5534DhA)]">
-              <textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                placeholder="설명을 입력해 주세요"
-                className="w-full px-[1.6rem] pt-[1.5rem] pb-[8.5rem] bg-[var(--white-FFFFFF)] text-lg-regular text-[var(--black-333236)] placeholder-[var(--gray-9FA6B2)] outline-none resize-none rounded-lg"
-              />
-            </div>
-          </div>
-
-          {/* 마감일 */}
-          <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
-            <label className="text-2lg-medium text-[var(--black-333236)]">
-              마감일
-            </label>
-            <div className="group flex items-center w-full h-[5rem] px-[1.6rem] border border-[var(--gray-D9D9D9)] rounded-lg focus-within:border-[var(--violet-5534DhA)]">
-              <Image
-                src="/assets/icon/calendar.svg"
-                alt="달력 아이콘"
-                width={22}
-                height={22}
-                className="mr-[0.8rem]"
-              />
-              <DatePicker
-                selected={selectedDate}
-                onChange={setSelectedDate}
-                dateFormat="yyyy.MM.dd HH:mm"
-                showTimeSelect
-                timeFormat="HH:mm"
-                timeIntervals={30}
-                timeCaption="시간"
-                placeholderText="날짜를 입력해 주세요"
-                className="flex-1 bg-transparent text-lg-regular text-[var(--black-333236)] placeholder-[var(--gray-9FA6B2)] outline-none"
-                locale={ko}
-              />
-            </div>
-          </div>
-
-          {/* 태그 */}
-          <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
-            <label className="text-2lg-medium text-[var(--black-333236)]">
-              태그
-            </label>
-            <div className="flex flex-wrap w-full min-h-[5rem] px-[1.6rem] py-[1rem] border border-[var(--gray-D9D9D9)] rounded-lg gap-[1rem] focus-within:border-[var(--violet-5534DhA)]">
-              {tags.map((tag, idx) => (
-                <Tag
-                  key={idx}
-                  label={tag.label}
-                  isDeletable
-                  onDelete={() => handleRemoveTag(idx)}
-                />
-              ))}
-              <input
-                type="text"
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={handleTagKeyDown}
-                placeholder={tags.length === 0 ? '입력 후 Enter' : ''}
-                className="flex-1 min-w-[10rem] bg-transparent text-lg-regular text-[var(--black-333236)] placeholder-[var(--gray-9FA6B2)] outline-none"
-              />
-            </div>
-          </div>
-
-          {/* 이미지 */}
-          <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
-            <label className="text-2lg-medium text-[var(--black-000000)]">
-              이미지
-            </label>
-            <div
-              className="relative w-[7.6rem] h-[7.6rem] rounded-[0.6rem] overflow-hidden cursor-pointer"
-              onClick={handleImageClick}
-            >
-              <Image
-                src={preview || '/assets/icon/example-edit-image.svg'}
-                alt="업로드된 이미지"
-                fill
-                className="object-cover"
-              />
-              <div className="absolute inset-0 bg-[rgba(0,0,0,0.6)] flex items-center justify-center">
-                <Image
-                  src="/assets/icon/pen.svg"
-                  alt="펜 아이콘"
-                  width={17}
-                  height={17}
+                <UserDropdown
+                  users={users}
+                  selectedUser={selectedUser}
+                  onChange={(user) => {
+                    setSelectedUser(user)
+                    if (
+                      cardInfo.assignee &&
+                      user &&
+                      user.id !== cardInfo.assignee.id
+                    )
+                      setIsDisable(false)
+                    else if (!cardInfo.assignee && user && user.id)
+                      setIsDisable(false)
+                    else setIsDisable(true)
+                  }}
+                  mode="select"
+                  setAssignee={setAssignee}
                 />
               </div>
-              <input
-                className="hidden"
-                ref={inputRef}
-                type="file"
-                accept="image/*"
-                onChange={handleImageChange}
+            </div>
+
+            {/* 제목 */}
+            <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
+              <label className="text-2lg-medium text-[var(--black-333236)] flex items-center gap-[2px]">
+                제목
+                <span className="text-[var(--violet-5534DhA)] text-lg-regular">
+                  *
+                </span>
+              </label>
+              <Input
+                value={title}
+                onChange={(e) => {
+                  setTitle(e.target.value)
+                  if (e.target.value != cardInfo.title) setIsDisable(false)
+                  else setIsDisable(true)
+                }}
+                placeholder="제목을 입력해 주세요"
+                height="5rem"
+                padding="1.2rem 1.6rem"
               />
             </div>
-          </div>
 
-          {/* 버튼 */}
-          <div className="w-full flex justify-center items-center gap-[0.8rem]">
-            <CommonButton
-              onClick={() => handleCardEditModal(false)}
-              variant="secondary"
-              padding="1.4rem 11.4rem"
-              isActive={true}
-              className="w-full h-[5.4rem] rounded-lg text-[var(--gray-787486)] text-lg-medium border border-[var(--gray-D9D9D9)]"
-            >
-              취소
-            </CommonButton>
-            <CommonButton
-              variant="primary"
-              padding="1.4rem 11.4rem"
-              isActive={true}
-              className="w-full h-[5.4rem] bg-[var(--violet-5534DhA)] text-[var(--white-FFFFFF)] text-lg-semibold"
-            >
-              수정
-            </CommonButton>
+            {/* 설명 */}
+            <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
+              <label className="text-2lg-medium text-[var(--black-333236)] flex items-center gap-[2px]">
+                설명
+                <span className="text-[var(--violet-5534DhA)] text-lg-regular">
+                  *
+                </span>
+              </label>
+              <div className="w-full border border-[var(--gray-D9D9D9)] rounded-lg focus-within:border-[var(--violet-5534DhA)]">
+                <textarea
+                  value={description}
+                  onChange={(e) => {
+                    setDescription(e.target.value)
+                    if (e.target.value != cardInfo.description)
+                      setIsDisable(false)
+                    else setIsDisable(true)
+                  }}
+                  placeholder="설명을 입력해 주세요"
+                  className="w-full px-[1.6rem] pt-[1.5rem] pb-[8.5rem] bg-[var(--white-FFFFFF)] text-lg-regular text-[var(--black-333236)] placeholder-[var(--gray-9FA6B2)] outline-none resize-none rounded-lg"
+                />
+              </div>
+            </div>
+
+            {/* 마감일 */}
+            <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
+              <label className="text-2lg-medium text-[var(--black-333236)]">
+                마감일
+              </label>
+              <div className="group flex items-center w-full h-[5rem] px-[1.6rem] border border-[var(--gray-D9D9D9)] rounded-lg focus-within:border-[var(--violet-5534DhA)]">
+                <Image
+                  src="/assets/icon/calendar.svg"
+                  alt="달력 아이콘"
+                  width={22}
+                  height={22}
+                  className="mr-[0.8rem]"
+                />
+                <DatePicker
+                  selected={selectedDate}
+                  onChange={(date) => {
+                    setSelectedDate(date)
+                    console.log(date?.toLocaleDateString())
+                    console.log(new Date(cardInfo.dueDate).toLocaleDateString())
+                    if (
+                      date?.toString() !== new Date(cardInfo.dueDate).toString()
+                    ) {
+                      setIsDisable(false)
+                    } else {
+                      setIsDisable(true)
+                    }
+                  }}
+                  dateFormat="yyyy.MM.dd HH:mm"
+                  showTimeSelect
+                  timeFormat="HH:mm"
+                  timeIntervals={30}
+                  timeCaption="시간"
+                  placeholderText="날짜를 입력해 주세요"
+                  className="flex-1 bg-transparent text-lg-regular text-[var(--black-333236)] placeholder-[var(--gray-9FA6B2)] outline-none"
+                  locale={ko}
+                />
+              </div>
+            </div>
+
+            {/* 태그 */}
+            <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
+              <label className="text-2lg-medium text-[var(--black-333236)]">
+                태그
+              </label>
+              <div className="flex flex-wrap w-full min-h-[5rem] px-[1.6rem] py-[1rem] border border-[var(--gray-D9D9D9)] rounded-lg gap-[1rem] focus-within:border-[var(--violet-5534DhA)]">
+                {tags.map((tag, idx) => (
+                  <Tag
+                    key={idx}
+                    label={tag.label}
+                    isDeletable
+                    onDelete={() => handleRemoveTag(idx)}
+                  />
+                ))}
+                <input
+                  type="text"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleTagKeyDown}
+                  placeholder={tags.length === 0 ? '입력 후 Enter' : ''}
+                  className="flex-1 min-w-[10rem] bg-transparent text-lg-regular text-[var(--black-333236)] placeholder-[var(--gray-9FA6B2)] outline-none"
+                />
+              </div>
+            </div>
+
+            {/* 이미지 */}
+            <div className="flex flex-col pb-[3.2rem] gap-[0.8rem]">
+              <label className="text-2lg-medium text-[var(--black-000000)]">
+                이미지
+              </label>
+              <div
+                className="w-[7.6rem] h-[7.6rem] relative flex items-center justify-center rounded-[0.6rem] bg-[#F5F5F5] cursor-pointer overflow-hidden"
+                onClick={handleImageClick}
+              >
+                {preview ? (
+                  <>
+                    <Image
+                      src={preview}
+                      alt="업로드된 이미지"
+                      fill
+                      className="rounded-[0.6rem] object-cover"
+                    />
+                    <div className="absolute inset-0 bg-[rgba(0,0,0,0.6)] flex items-center justify-center">
+                      <Image
+                        src="/assets/icon/pen.svg"
+                        alt="펜 아이콘"
+                        width={17}
+                        height={17}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <Image
+                    src="/assets/icon/add.svg"
+                    alt="이미지 추가"
+                    width={17}
+                    height={17}
+                  />
+                )}
+
+                <input
+                  className="hidden"
+                  ref={inputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleImageChange}
+                />
+              </div>
+            </div>
+
+            {/* 버튼 */}
+            <div className="w-full flex justify-center items-center gap-[0.8rem]">
+              <CommonButton
+                onClick={() => handleCardEditModal(false)}
+                variant="secondary"
+                padding="1.4rem 11.4rem"
+                isActive={true}
+                className="w-full h-[5.4rem] rounded-lg text-[var(--gray-787486)] text-lg-medium border border-[var(--gray-D9D9D9)]"
+              >
+                취소
+              </CommonButton>
+              <CommonButton
+                variant="primary"
+                padding="1.4rem 11.4rem"
+                isActive={!IsDisable}
+                className="w-full h-[5.4rem] bg-[var(--violet-5534DhA)] text-[var(--white-FFFFFF)] text-lg-semibold"
+                onClick={handleSubmitForm}
+              >
+                수정
+              </CommonButton>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </AnimatedModalContainer>
   )
 }

--- a/src/components/domain/modals/taskcardmodal/TaskCardModal.tsx
+++ b/src/components/domain/modals/taskcardmodal/TaskCardModal.tsx
@@ -8,6 +8,7 @@ import { CardType } from '@/types/api/cards'
 import { useAuthStore } from '@/stores/auth'
 import AnimatedModalContainer from '@/components/common/animatedmodalcontainer/AnimatedModalContainer'
 import Badge from '@/components/common/badge/Badge'
+import { ColumnType } from '@/types/api/columns'
 
 export const formatDate = (isoDate: string): string => {
   const date = new Date(isoDate)
@@ -22,7 +23,7 @@ export const formatDate = (isoDate: string): string => {
 interface Props {
   card: CardType
   dashboardId: number
-  columnInfo: { columnId: number; columnTitle: string }
+  columnInfo: ColumnType
   onClose: () => void
   onEdit: (card: CardType) => void
   onDelete: (cardId: number) => void
@@ -75,7 +76,7 @@ export default function TaskCardModal({
       const newComment = await commentsService.postComments({
         cardId: Number(card.id),
         content: inputComment,
-        columnId: columnInfo.columnId,
+        columnId: columnInfo.id,
         dashboardId: dashboardId,
       })
       setComments((prev) => [newComment, ...prev])
@@ -235,7 +236,7 @@ export default function TaskCardModal({
             <div className={styles.statusTagRow}>
               <div className="rounded-full bg-[#F1EFFD] px-[1rem] py-[0.4rem] flex justify-centeri items-center text-[#5534DA] text-xs-regular">
                 <div className="w-[0.6rem] h-[0.6rem] bg-[#5534DA] mr-[0.6rem] rounded-full"></div>
-                <div>{columnInfo.columnTitle}</div>
+                <div>{columnInfo.title}</div>
               </div>
               <div className="w-[0.1rem] h-[2rem] bg-[#D9D9D9] mx-[2rem]"></div>
               <div className={styles.tagList}>
@@ -253,7 +254,13 @@ export default function TaskCardModal({
 
             {card.imageUrl && (
               <div className={styles.imageWrapper}>
-                <Image src={card.imageUrl} alt="카드 이미지" fill priority />
+                <Image
+                  className="rounded-[0.6rem] object-cover"
+                  src={card.imageUrl}
+                  alt="카드 이미지"
+                  fill
+                  priority
+                />
               </div>
             )}
           </div>

--- a/src/components/dropdown/StatusDropdown.tsx
+++ b/src/components/dropdown/StatusDropdown.tsx
@@ -1,15 +1,17 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
 import Image from 'next/image'
+import { useEffect, useRef, useState, useCallback } from 'react'
+
 import styles from './statusDropdown.module.css'
+import { ColumnType } from '@/types/api/columns'
 
 interface StatusDropdownProps {
-  statusList: string[]
-  value: string
-  onChange: (status: string) => void
+  columnList: ColumnType[]
+  value: ColumnType
+  onChange: (column: ColumnType) => void
 }
 
 export default function StatusDropdown({
-  statusList,
+  columnList,
   value,
   onChange,
 }: StatusDropdownProps) {
@@ -19,7 +21,7 @@ export default function StatusDropdown({
   const optionRefs = useRef<(HTMLLIElement | null)[]>([])
 
   useEffect(() => {
-    optionRefs.current = new Array(statusList.length).fill(null)
+    optionRefs.current = new Array(columnList.length).fill(null)
   }, [])
 
   const assignOptionRef = useCallback(
@@ -29,8 +31,8 @@ export default function StatusDropdown({
     []
   )
 
-  const handleStatusSelect = (status: string) => {
-    onChange(status)
+  const handleStatusSelect = (column: ColumnType) => {
+    onChange(column)
     setIsDropdownOpen(false)
   }
 
@@ -46,19 +48,19 @@ export default function StatusDropdown({
 
       if (event.key === 'ArrowDown') {
         event.preventDefault()
-        setFocusedIndex((prev) => (prev + 1) % statusList.length)
+        setFocusedIndex((prev) => (prev + 1) % columnList.length)
       }
 
       if (event.key === 'ArrowUp') {
         event.preventDefault()
         setFocusedIndex(
-          (prev) => (prev - 1 + statusList.length) % statusList.length
+          (prev) => (prev - 1 + columnList.length) % columnList.length
         )
       }
 
       if (event.key === 'Enter') {
         event.preventDefault()
-        handleStatusSelect(statusList[focusedIndex])
+        handleStatusSelect(columnList[focusedIndex])
       }
     }
 
@@ -89,7 +91,7 @@ export default function StatusDropdown({
     }
   }, [focusedIndex, isDropdownOpen])
 
-  const isSelected = (status: string) => value === status
+  const isSelected = (column: ColumnType) => value.id === column.id
 
   return (
     <div ref={dropdownContainerRef} className={styles.container}>
@@ -97,7 +99,7 @@ export default function StatusDropdown({
         type="button"
         onClick={() => {
           setIsDropdownOpen((prev) => !prev)
-          setFocusedIndex(statusList.findIndex((s) => s === value))
+          setFocusedIndex(columnList.findIndex((s) => s.id === value.id))
         }}
         className={`${styles.triggerButton} ${
           isDropdownOpen ? styles.open : styles.closed
@@ -105,7 +107,7 @@ export default function StatusDropdown({
       >
         <div className={styles.selectedStatus}>
           <span className={styles.statusDot} />
-          <span className={styles.statusText}>{value}</span>
+          <span className={styles.statusText}>{value.title}</span>
         </div>
         <Image
           src="/assets/image/arrow-down.svg"
@@ -120,16 +122,16 @@ export default function StatusDropdown({
 
       {isDropdownOpen && (
         <ul className={styles.dropdown}>
-          {statusList.map((status, index) => (
+          {columnList.map((column, index) => (
             <li
-              key={status}
+              key={column.id}
               ref={(el) => assignOptionRef(el, index)}
-              onClick={() => handleStatusSelect(status)}
+              onClick={() => handleStatusSelect(column)}
               className={`${styles.option} ${
                 index === focusedIndex ? styles.focused : ''
-              } ${isSelected(status) ? styles.selected : ''}`}
+              } ${isSelected(column) ? styles.selected : ''}`}
             >
-              {isSelected(status) ? (
+              {isSelected(column) ? (
                 <Image
                   src="/assets/image/check.svg"
                   alt="선택됨"
@@ -141,7 +143,7 @@ export default function StatusDropdown({
               )}
               <div className={styles.selectedStatus}>
                 <span className={styles.statusDot} />
-                <span className={styles.statusText}>{status}</span>
+                <span className={styles.statusText}>{column.title}</span>
               </div>
             </li>
           ))}

--- a/src/types/api/cards.ts
+++ b/src/types/api/cards.ts
@@ -37,11 +37,11 @@ export interface CreateCardBody {
 }
 
 export interface UpdateCardBody {
-  assigneeUserId: number
+  assigneeUserId?: number
   columnId: number
   title: string
   description: string
-  dueDate: string
+  dueDate?: string
   tags: string[]
-  imageUrl: string
+  imageUrl?: string
 }


### PR DESCRIPTION
## 📌 PR 개요
할 일 수정 모달 기능 구현(수정, input 기본값 유지, 수정 내용 반영)

## 🏃‍♂️‍➡️ 요구사항
### 할 일 카드 상세 모달 구현하기(/dashboard/{dashboardid}) - 할 일 카드 수정 모달 구현하기
- [x]  만들어진 카드 정보로 input이 기본값으로 채워지도록 하세요.
- [x]  값이 하나라도 바뀌면 '수정' 버튼이 활성화되도록 하세요.
- [x]  '수정' 버튼을 클릭하면 해당 카드에 수정된 정보가 반영되도록 하세요.

## 🔥 변경 사항
- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 할 일 수정 모달 들어갈 시에 데이터 유지
- 할 일 수정에서 하나라도 변경점이 있을 시에만 수정 버튼 활성화
  - 태그는 제외
  - 이미지 없을 때에는 + 버튼으로, 변경된 이미지도 잘 보이게
- 필수 요소인, 제목과 설명 미기입 시 수정 버튼 비활성화 처리
- 수정 버튼 클릭 시, 카드 내용 변경
- 카드 state 변경 시에 column 변경되도록 설정 완료

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/46565699-0586-43e7-8b84-9ad25fd9876d)
수정 버튼 비활성화
![image](https://github.com/user-attachments/assets/91de9a95-2e10-4a04-837d-e124e6d38ea6)
수정 버튼 활성화
![image](https://github.com/user-attachments/assets/55f356eb-a42a-4fb9-a443-5983509d2a15)
필수 요소 제목과 설명 없을 시 수정 버튼 비활성화

## 🚧 관련 이슈
SCRUM - 37, 38, 39

## 💡 추가 정보
- 태그는 지워도 변경 버튼이 다시 비활성화 되지는 않습니다.