### PR TITLE
[Fix/task-card-modal] 날짜 오류 및 할 일 수정 담당자 placholder 변경

### DIFF
--- a/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
+++ b/src/components/domain/modals/taskcardeditmodal/TaskCardEditModal.tsx
@@ -55,7 +55,7 @@ export default function TaskCardEditModal({
   const [assignee, setAssignee] = useState(-1)
   const [description, setDescription] = useState(cardInfo.description)
   const [selectedDate, setSelectedDate] = useState<Date | null>(
-    new Date(cardInfo.dueDate)
+    cardInfo.dueDate ? new Date(cardInfo.dueDate) : null
   )
 
   const [inputValue, setInputValue] = useState('')

--- a/src/components/domain/modals/taskcardmodal/TaskCardModal.tsx
+++ b/src/components/domain/modals/taskcardmodal/TaskCardModal.tsx
@@ -227,7 +227,7 @@ export default function TaskCardModal({
             <div>
               <div className="text-[#000000] text-xs-semibold">마감일</div>
               <div className="text-[#333236] text-md-regular">
-                {formatDate(card.dueDate)}
+                {card.dueDate ? formatDate(card.dueDate) : ''}
               </div>
             </div>
           </section>

--- a/src/components/dropdown/UserDropdown.tsx
+++ b/src/components/dropdown/UserDropdown.tsx
@@ -176,7 +176,7 @@ export default function UserDropdown({
                 )
               ) : (
                 <span className={styles.userName}>
-                  {'이름을 입력해 주세요'}
+                  {'이름을 선택해 주세요'}
                 </span>
               )}
             </div>


### PR DESCRIPTION
## 📌 PR 개요
날짜 미선택 시, 1970년도로 뜨느 오류, 할 일 수정 담당자 placeholder 변경

## 🏃‍♂️‍➡️ 요구사항

## 🔥 변경 사항
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 날짜 미입력 시, 카드와 할 일 생성 모달에서 1970년도로 뜨는 오류 수정
- 할 일 수정 담당자 placeholder 기능에 맞게 "이름을 선택해 주세요."로 변경

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/fe23089f-ea9b-477d-bcae-249965d89bc2)
카드에서 날짜 미선택시
![image](https://github.com/user-attachments/assets/dfcf8e6d-08e7-45c0-86af-b4adf3f267b8)
할 일 수정 모달에서의 담당자 placeholder와 날짜 처리


## 🚧 관련 이슈

## 💡 추가 정보
