### PR TITLE
[Style/modal]: 대시보드 모달 버튼 수정 및 반응형 추가

### DIFF
--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -16,6 +16,7 @@ export interface ColumnProps {
   handleCardCreateModalOpen: (columnId: number) => void
   handleColumnEditModal: (state: boolean) => void
   handleColumnOptionClick: (columnInfo: ColumnType) => void
+  handleDeleteColumnConfirm: (column: ColumnType) => void
 }
 
 export default function Column({

--- a/src/components/domain/modals/basemodal/ConfirmActionModal.tsx
+++ b/src/components/domain/modals/basemodal/ConfirmActionModal.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import styles from '@/components/domain/modals/basemodal/modal.module.css'
 import baseStyle from '@/components/domain/modals/basemodal/baseModal.module.css'
 import ModalButton from './ModalButton'
-import { ModalProps } from '@/types/common/modal'
+import { Actionmodal } from '@/types/common/actionmodal'
 
 export default function ConfirmActionModal({
   message,
   onConfirm,
   size = 'small',
-  confirmLabel = '확인', // 기본값을 '확인'으로 설정
-}: ModalProps) {
+  confirmLabel = '확인',
+}: Actionmodal) {
   // 모달 크기에 따른 스타일 계산
   const getModalClassNames = (size: string) => {
     return {

--- a/src/components/domain/modals/basemodal/FormModal.tsx
+++ b/src/components/domain/modals/basemodal/FormModal.tsx
@@ -113,6 +113,7 @@ export default function FormModal(props: FormModalProps) {
                   label="생성"
                   isCancel={false}
                   size={size}
+                  disabled={props.isSubmitDisabled}
                 />
               </>
             )}

--- a/src/components/domain/modals/basemodal/ModalButton.tsx
+++ b/src/components/domain/modals/basemodal/ModalButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import baseStyle from './basemodal.module.css'
+import baseStyle from './baseModal.module.css'
 import styles from './modal.module.css'
 
 interface ModalButtonProps {
@@ -8,6 +8,7 @@ interface ModalButtonProps {
   label: string
   isCancel?: boolean
   size: 'small' | 'large'
+  disabled?: boolean
 }
 
 const ModalButton: React.FC<ModalButtonProps> = ({
@@ -16,32 +17,27 @@ const ModalButton: React.FC<ModalButtonProps> = ({
   label,
   isCancel = false,
   size,
+  disabled,
 }) => {
   let buttonClass = ''
 
   if (isCancel) {
     // 취소 버튼일 경우
-    if (size === 'large') {
-      buttonClass = styles.cancelLarge
-    } else {
-      buttonClass = styles.cancelSmall
-    }
+    buttonClass = size === 'large' ? styles.cancelLarge : styles.cancelSmall
   } else {
     // 확인 버튼일 경우
-    if (size === 'large') {
-      buttonClass = styles.confirmLarge
-    } else {
-      buttonClass = styles.confirmSmall
-    }
+    buttonClass = size === 'large' ? styles.confirmLarge : styles.confirmSmall
   }
+
+  const baseClass = baseStyle[isCancel ? 'cancelButton' : 'confirmButton']
+  const disabledClass = disabled ? baseStyle.disabledButton : ''
 
   return (
     <button
       type={type}
-      className={`${baseStyle.button} ${
-        baseStyle[isCancel ? 'cancelButton' : 'confirmButton']
-      } ${buttonClass}`}
+      className={`${baseStyle.button} ${baseClass} ${buttonClass} ${disabledClass}`.trim()}
       onClick={onClick}
+      disabled={disabled}
     >
       {label}
     </button>

--- a/src/components/domain/modals/basemodal/baseModal.module.css
+++ b/src/components/domain/modals/basemodal/baseModal.module.css
@@ -3,7 +3,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   background: rgba(0, 0, 0, 0.3);
   display: flex;
@@ -53,7 +53,12 @@
   color: var(--white-FFFFFF);
   border: none;
 }
-
+.disabledButton {
+  background-color: var(--gray-D9D9D9) !important;
+  color: var(--gray-787486) !important;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
 /* 공통 애니메이션 */
 @keyframes fadeIn {
   from {

--- a/src/components/domain/modals/basemodal/modal.module.css
+++ b/src/components/domain/modals/basemodal/modal.module.css
@@ -4,7 +4,7 @@
 }
 
 .large {
-  padding: 3rem 2.2rem;
+  padding: 2.5rem 2.2rem;
 }
 
 .alertSmall {

--- a/src/pages/dashboard/[id]/dashboard.module.css
+++ b/src/pages/dashboard/[id]/dashboard.module.css
@@ -1,7 +1,6 @@
 .container {
   min-height: calc(100vh - 7rem);
   display: flex;
-  /* min-height: 100vh; */
   background-color: var(--gray-FAFAFA);
 }
 

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -13,6 +13,7 @@ import {
   UpdateColumnBody,
 } from '@/types/api/columns'
 import FormModal from '@/components/domain/modals/basemodal/FormModal'
+import DeleteActionModal from '@/components/domain/modals/basemodal/DeleteActionModal'
 
 export default function DashboardPage() {
   const [columns, setColumns] = useState<ColumnType[]>([])
@@ -20,10 +21,13 @@ export default function DashboardPage() {
     null
   )
   const [refreshTrigger, setRefreshTrigger] = useState<number>(0)
-
+  const [isMobile, setIsMobile] = useState(false)
   const [isCardCreateModalOpen, setIsCardCreateModalOpen] = useState(false)
   const [isColumnCreateModal, setIsColumnCreateModal] = useState(false)
   const [isColumnEditModal, setIsColumnEditModal] = useState(false)
+  const [isDeleteConfirmModalOpen, setIsDeleteConfirmModalOpen] =
+    useState(false)
+  const [columnModalError, setColumnModalError] = useState<string>('')
 
   const [selectedColumnId, setSelectedColumnId] = useState<number>(-1)
   const [columnModalInput, setColumnModalInput] = useState<string>('')
@@ -33,6 +37,10 @@ export default function DashboardPage() {
   const getColumns = async () => {
     const columnsData = await columnsService.getColumns(dashboardId)
     setColumns(columnsData.data)
+  }
+
+  const isDuplicateColumnTitle = (title: string) => {
+    return columns.some((column) => column.title === title.trim())
   }
 
   const handleCardCreateModalOpen = (columnId: number) => {
@@ -61,6 +69,7 @@ export default function DashboardPage() {
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     setColumnModalInput(e.target.value)
+    setColumnModalError('')
   }
 
   const handleColumnOptionClick = (columnInfo: ColumnType) => {
@@ -68,8 +77,37 @@ export default function DashboardPage() {
     setColumnModalInput(columnInfo.title)
   }
 
+  const handleDeleteColumnConfirm = (column: ColumnType) => {
+    setTriggeredColumn(column)
+    setIsDeleteConfirmModalOpen(true)
+    setIsColumnEditModal(false)
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!triggeredColumn) return
+    try {
+      await columnsService.deleteColumns(triggeredColumn.id)
+      const result = columns.filter((col) => col.id !== triggeredColumn.id)
+      setColumns(result)
+      setTriggeredColumn(null)
+      setIsDeleteConfirmModalOpen(false)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   const postColumn = async () => {
     try {
+      if (isDuplicateColumnTitle(columnModalInput)) {
+        setColumnModalError('중복된 컬럼입니다')
+        return
+      }
+
+      if (columnModalInput.trim() === '') {
+        setColumnModalError('이름을 입력해주세요')
+        return
+      }
+
       const reqBody: CreateColumnBody = {
         title: columnModalInput,
         dashboardId: dashboardId,
@@ -79,10 +117,12 @@ export default function DashboardPage() {
       setColumns(result)
       setIsColumnCreateModal(false)
       setColumnModalInput('')
+      setColumnModalError('')
     } catch (err) {
       console.error(err)
     }
   }
+
   const putColumn = async (columnId: number) => {
     try {
       const reqBody: UpdateColumnBody = {
@@ -96,42 +136,37 @@ export default function DashboardPage() {
         return column
       })
       setColumns(result)
-      // const result = [...columns, res]
-      // setColumns(result)
       handleColumnEditModal(false)
-    } catch (err) {
-      console.error(err)
-    }
-  }
-
-  const deleteColumn = async (columnId: number) => {
-    try {
-      await columnsService.deleteColumns(columnId)
-      const result = columns.filter((column) => column.id !== columnId)
-      setColumns(result)
-      handleColumnEditModal(false)
-      setColumnModalInput('')
     } catch (err) {
       console.error(err)
     }
   }
 
   useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 767)
+    }
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  useEffect(() => {
     if (!query.id) return
     if (isNaN(dashboardId)) {
-      // 대시보드 ID가 유효하지 않으면 404 페이지로 리다이렉트
       push('/404')
     } else {
       getColumns()
     }
   }, [query.id, dashboardId, push])
 
-  // 404 리다이렉트 구현 필요
   if (!dashboardId || isNaN(dashboardId)) return null
+
+  const isCreateDisabled = columnModalInput.trim() === ''
+  isDuplicateColumnTitle(columnModalInput) || columnModalError !== ''
 
   return (
     <>
-      {/* 컬럼 리스트 */}
       <div className={styles.container}>
         {columns.map((column) => (
           <Column
@@ -143,10 +178,9 @@ export default function DashboardPage() {
             handleCardCreateModalOpen={handleCardCreateModalOpen}
             handleColumnEditModal={handleColumnEditModal}
             handleColumnOptionClick={handleColumnOptionClick}
+            handleDeleteColumnConfirm={handleDeleteColumnConfirm}
           />
         ))}
-
-        {/* 새로운 컬럼 추가하기 버튼 */}
 
         <div className={styles.addColumnWrapper}>
           <ButtonDashboard
@@ -172,6 +206,7 @@ export default function DashboardPage() {
           </ButtonDashboard>
         </div>
       </div>
+
       {isCardCreateModalOpen && (
         <TaskCardCreateModal
           dashboardId={dashboardId}
@@ -180,6 +215,7 @@ export default function DashboardPage() {
           setRefreshTrigger={setRefreshTrigger}
         />
       )}
+
       {isColumnCreateModal && (
         <FormModal
           title="새 컬럼 생성"
@@ -190,22 +226,40 @@ export default function DashboardPage() {
           onCancel={() => {
             handleColumnCreateModal(false)
             setColumnModalInput('')
+            setColumnModalError('')
           }}
           mode="default"
+          size={isMobile ? 'small' : 'large'}
+          errorMessage={columnModalError}
+          isSubmitDisabled={isCreateDisabled}
         />
       )}
-      {isColumnEditModal && triggeredColumn && (
+
+      {isColumnEditModal && triggeredColumn && !isDeleteConfirmModalOpen && (
         <FormModal
           title="컬럼 관리"
           inputLabel="이름"
           inputValue={columnModalInput}
           onChange={handleColumnModalInputChange}
           onEdit={() => putColumn(triggeredColumn.id)}
-          onDelete={() => deleteColumn(triggeredColumn.id)}
+          onDelete={() => handleDeleteColumnConfirm(triggeredColumn)}
           onCancel={() => handleColumnEditModal(false)}
           cancelLabel="삭제"
           mode="delete"
           showCloseButton={true}
+          size={isMobile ? 'small' : 'large'}
+        />
+      )}
+
+      {isDeleteConfirmModalOpen && triggeredColumn && (
+        <DeleteActionModal
+          message="정말 이 컬럼을 삭제하시겠습니까?"
+          onCancel={() => {
+            setIsDeleteConfirmModalOpen(false)
+            setIsColumnEditModal(true)
+          }}
+          onDelete={handleConfirmDelete}
+          size={isMobile ? 'small' : 'large'}
         />
       )}
     </>

--- a/src/types/common/actionmodal.ts
+++ b/src/types/common/actionmodal.ts
@@ -1,0 +1,6 @@
+export interface Actionmodal {
+  message: string
+  onConfirm: () => void
+  size?: 'small' | 'large'
+  confirmLabel?: string
+}

--- a/src/types/common/formmodal.ts
+++ b/src/types/common/formmodal.ts
@@ -8,6 +8,8 @@ type BaseProps = {
   size?: 'small' | 'large'
   cancelLabel?: string
   showCloseButton?: boolean
+  isSubmitDisabled?: boolean
+  isActive?: boolean
 }
 
 // 생성 모드

--- a/src/types/common/modal.ts
+++ b/src/types/common/modal.ts
@@ -1,12 +1,11 @@
 export type ModalSize = 'small' | 'large'
 
-export type ModalProps = {
+export interface ModalProps {
   message: string
-  onConfirm: () => void
-  onCancel?: () => void
-  onDelete?: () => void
-  size?: ModalSize
-  confirmLabel?: string
+  onCancel: () => void
+  onDelete: () => void
   cancelLabel?: string
   deleteLabel?: string
+
+  size?: 'small' | 'large'
 }


### PR DESCRIPTION
## 📌 PR 개요
대시보드 모달 버튼 수정 및 반응형 추가

## 🏃‍♂️‍➡️ 요구사항
- [x]  이름 input에 입력값이 없으면 '생성' 버튼은 비활성화되도록 하세요.
- [x]  컬럼 이름이 중복되면 “중복된 컬럼 이름입니다”라는 경고창을 보여주도록 하세요.
- [x]  활성화된 '생성' 버튼을 클릭하면 컬럼이 추가되도록 하세요.
- [x]  '삭제하기' 버튼을 클릭하면 “컬럼의 모든 카드가 삭제됩니다”라는 경고창을 보여주도록 하세요.
- [x]  '예' 버튼을 클릭하면 해당 컬럼의 모든 할 일 카드들이 삭제되도록 하세요.

## 🔥 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📷 스크린샷 (선택)
![빈칸 비활성화](https://github.com/user-attachments/assets/af926aa1-a6ab-4746-b7eb-b522b923ad62)
![중복칼럼](https://github.com/user-attachments/assets/8368e6b9-4306-4014-a314-49e25fb1d4bb)
![변경](https://github.com/user-attachments/assets/4f3b8108-89af-4b89-ac3d-2f15c31d484c)
![삭제](https://github.com/user-attachments/assets/fa402e61-c57c-46b6-ad6c-007bbe8fc327)
### 삭제 알림에서 취소 버튼 누르면 -> 다시 변경 삭제 모달로 바뀜
### 생성 버튼은 input이 빈 칸일 경우 버튼 비활성화로 되도록 구현


## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 여기에 적어주세요 -->