### PR TITLE
[Fix/homenavbar-invite] homenavbar에서 초대하기 중복 요청 불가 처리 및 그 밖의 에러사항 수정

### DIFF
--- a/src/components/layout/gnb/HomeNavBar.tsx
+++ b/src/components/layout/gnb/HomeNavBar.tsx
@@ -33,7 +33,7 @@ export default function HomeNavBar({
       case 'mydashboard':
         return '내 대시보드'
       case 'dashboard':
-        return dashboardTitle || '대시보드 제목 없음'
+        return dashboardTitle
       case 'mypage':
         return '계정관리'
       default:

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -37,7 +37,7 @@ export default function Layout({ children, pageType }: LayoutProps) {
   const { setMembers } = useDashboardMembers()
   const [inviteModalOpen, setInviteModalOpen] = useState(false)
   const [isOwner, setIsOwner] = useState(false)
-  const [dashboardTitle, setDashboardTitle] = useState('대시보드 제목 없음')
+  const [dashboardTitle, setDashboardTitle] = useState('')
   const [membersEmail, setMembersEmail] = useState('')
   const [error, setError] = useState('')
   const dashboardId = Number(router.query.id)
@@ -51,6 +51,20 @@ export default function Layout({ children, pageType }: LayoutProps) {
     }
 
     try {
+      const inviteList = await dashboardsService.getDashboardsInvitations(
+        dashboardId,
+        1,
+        20
+      )
+
+      const filteredInviteList = inviteList.invitations.filter(
+        (invitation) => invitation.invitee.email === membersEmail
+      )
+      if (filteredInviteList.length) {
+        alert('❌ 이미 초대한 이메일입니다 ❌')
+        return
+      }
+
       await dashboardsService.postDashboardsInvitations(dashboardId, {
         email: membersEmail,
       })

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -116,7 +116,6 @@ export default function Sidebar({
         </li>
         <ul className="h-[580px]">
           {dashboardList &&
-            dashboardList.length &&
             dashboardList.map((dashboard) => (
               <li key={dashboard.id}>
                 <Link
@@ -147,36 +146,37 @@ export default function Sidebar({
             ))}
         </ul>
       </ul>
-
-      <article className="w-full flex justify-between items-center mt-[32px]">
-        <button
-          className="w-[40px] h-[40px] border-2 border-[#D9D9D9] rounded-l-[6px] flex justify-center items-center cursor-pointer"
-          onClick={() => handlePageMove('left')}
-        >
-          <Image
-            className="w-[16px] h-[16px]"
-            src="/assets/icon/arrow-left-gray.svg"
-            width={16}
-            height={16}
-            alt="왼쪽 화살표"
-          />
-        </button>
-        <div>
-          {page} / {Math.ceil(totalCount / 10)}
-        </div>
-        <button
-          className="w-[40px] h-[40px] border-2 border-[#D9D9D9] rounded-r-[6px] flex justify-center items-center cursor-pointer"
-          onClick={() => handlePageMove('right')}
-        >
-          <Image
-            className="w-[16px] h-[16px]"
-            src="/assets/icon/arrow-right-gray.svg"
-            width={16}
-            height={16}
-            alt="오른쪽 화살표"
-          />
-        </button>
-      </article>
+      {dashboardList.length ? (
+        <article className="w-full flex justify-between items-center mt-[32px]">
+          <button
+            className="w-[40px] h-[40px] border-2 border-[#D9D9D9] rounded-l-[6px] flex justify-center items-center cursor-pointer"
+            onClick={() => handlePageMove('left')}
+          >
+            <Image
+              className="w-[16px] h-[16px]"
+              src="/assets/icon/arrow-left-gray.svg"
+              width={16}
+              height={16}
+              alt="왼쪽 화살표"
+            />
+          </button>
+          <div>
+            {page} / {Math.ceil(totalCount / 10)}
+          </div>
+          <button
+            className="w-[40px] h-[40px] border-2 border-[#D9D9D9] rounded-r-[6px] flex justify-center items-center cursor-pointer"
+            onClick={() => handlePageMove('right')}
+          >
+            <Image
+              className="w-[16px] h-[16px]"
+              src="/assets/icon/arrow-right-gray.svg"
+              width={16}
+              height={16}
+              alt="오른쪽 화살표"
+            />
+          </button>
+        </article>
+      ) : null}
 
       {isModalOpen && <DashboardCreateModal onClose={handleCloseModal} />}
     </div>


### PR DESCRIPTION
## 📌 PR 개요
homenavbar에서 초대하기 중복 요청 불가 처리 및 사이드바 0 뜨는 문제와 '대시보드 이름 없음' ux 수정

## 🏃‍♂️‍➡️ 요구사항

## 🔥 변경 사항

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용
- 한 대시보드에서 중복 초대 안되게 처리
- 중복 초대 요청 시, alert 띄우기
- 로딩 중 아무 대시보드 이름 안 뜨게 처리
- 사이드바에 대시보드에 아무것도 없을 경우, page와 버튼 모두 안 보이게 처리 (0도 안 보임)

## 📷 스크린샷
![image (11)](https://github.com/user-attachments/assets/016b4a74-28ff-48fe-9822-0da81b2cb2c1)
한 대시보드에서 중복 초대 안되게 처리 및 중복 요청 시 alert 띄우기
![image](https://github.com/user-attachments/assets/5f187535-2342-4d7c-a027-5f2604d82075)
로딩 중에 '대시보드 이름 없음' 안 뜨게 처리
![image](https://github.com/user-attachments/assets/8cb25ba4-a0e1-40f9-9352-bb4078b97bde)
대시보드 아무것도 없을 때의 사이드바
![image](https://github.com/user-attachments/assets/528f7ee7-e84b-4725-b016-a042b8d27e5b)
대시보드 생기면 버튼과 페이지 수가 보이는 모습

## 🚧 관련 이슈


## 💡 추가 정보
