### PR TITLE
[Feat/card-infinite] 각 컬럼마다 카드 무한 스크롤 구현

### DIFF
--- a/src/components/domain/dashboard/CardTable.tsx
+++ b/src/components/domain/dashboard/CardTable.tsx
@@ -26,24 +26,25 @@ export default function CardTable({
   const observerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    if (!observerRef.current || !onLoadMore) return
-
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && !isLoading && hasMore) {
-          console.log('[IntersectionObserver] 트리거됨 - onLoadMore 호출')
-          onLoadMore() // 여기에서 데이터를 불러옵니다
+        if (entry.isIntersecting && hasMore && !isLoading && onLoadMore) {
+          onLoadMore()
         }
       },
-      {
-        rootMargin: '100px', // 마지막 카드가 화면에 보일 때 트리거
-      }
+      { threshold: 1 }
     )
 
-    observer.observe(observerRef.current)
+    if (observerRef.current) {
+      observer.observe(observerRef.current)
+    }
 
-    return () => observer.disconnect()
-  }, [onLoadMore, isLoading, hasMore])
+    return () => {
+      if (observerRef.current) {
+        observer.unobserve(observerRef.current)
+      }
+    }
+  }, [hasMore, isLoading, onLoadMore])
 
   return (
     <div className="flex flex-col gap-4 px-[2rem]">
@@ -57,7 +58,8 @@ export default function CardTable({
           />
         </div>
       ))}
-      <div ref={observerRef} /> {/* 마지막 카드 감지용 div */}
+      {/* 관찰용 div는 내부로 */}
+      <div ref={observerRef} style={{ height: '10px' }} />
     </div>
   )
 }

--- a/src/components/domain/dashboard/CardTable.tsx
+++ b/src/components/domain/dashboard/CardTable.tsx
@@ -1,4 +1,4 @@
-// 카드 리스트들
+import { useRef, useEffect } from 'react'
 import Card from '@/components/domain/dashboard/Card'
 import { CardType } from '@/types/api/cards'
 import { ColumnType } from '@/types/api/columns'
@@ -9,6 +9,9 @@ interface CardTableProps {
   dashboardId: number
   columnInfo: ColumnType
   setRefreshTrigger: React.Dispatch<SetStateAction<number>>
+  onLoadMore?: () => void
+  isLoading: boolean
+  hasMore: boolean
 }
 
 export default function CardTable({
@@ -16,18 +19,45 @@ export default function CardTable({
   dashboardId,
   columnInfo,
   setRefreshTrigger,
+  onLoadMore,
+  isLoading,
+  hasMore,
 }: CardTableProps) {
+  const observerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!observerRef.current || !onLoadMore) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !isLoading && hasMore) {
+          console.log('[IntersectionObserver] 트리거됨 - onLoadMore 호출')
+          onLoadMore() // 여기에서 데이터를 불러옵니다
+        }
+      },
+      {
+        rootMargin: '100px', // 마지막 카드가 화면에 보일 때 트리거
+      }
+    )
+
+    observer.observe(observerRef.current)
+
+    return () => observer.disconnect()
+  }, [onLoadMore, isLoading, hasMore])
+
   return (
     <div className="flex flex-col gap-4 px-[2rem]">
-      {cards.map((card) => (
-        <Card
-          key={card.id}
-          cardInfo={card}
-          dashboardId={dashboardId}
-          columnInfo={columnInfo}
-          setRefreshTrigger={setRefreshTrigger}
-        />
+      {cards.map((card, index) => (
+        <div key={`${card.id}-${index}`}>
+          <Card
+            cardInfo={card}
+            dashboardId={dashboardId}
+            columnInfo={columnInfo}
+            setRefreshTrigger={setRefreshTrigger}
+          />
+        </div>
       ))}
+      <div ref={observerRef} /> {/* 마지막 카드 감지용 div */}
     </div>
   )
 }

--- a/src/components/domain/dashboard/CardTable.tsx
+++ b/src/components/domain/dashboard/CardTable.tsx
@@ -24,7 +24,7 @@ export default function CardTable({
   hasMore,
 }: CardTableProps) {
   const observerRef = useRef<HTMLDivElement | null>(null)
-
+  // 관찰용 useEffectss
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -58,7 +58,7 @@ export default function CardTable({
           />
         </div>
       ))}
-      {/* 관찰용 div는 내부로 */}
+
       <div ref={observerRef} style={{ height: '10px' }} />
     </div>
   )

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -153,7 +153,7 @@ export default function Column({
               hasMore={hasMore}
             />
 
-            {/* 관찰용 div는 카드 아래! */}
+            {/* 관찰용 div*/}
             <div
               ref={observerRef}
               style={{ height: '10px', backgroundColor: 'transparent' }}

--- a/src/components/domain/dashboard/Column.tsx
+++ b/src/components/domain/dashboard/Column.tsx
@@ -21,78 +21,131 @@ export interface ColumnProps {
 export default function Column({
   columnInfo,
   dashboardId,
-  refreshTrigger,
   setRefreshTrigger,
   handleCardCreateModalOpen,
   handleColumnEditModal,
   handleColumnOptionClick,
 }: ColumnProps) {
-  const [cards, setCards] = useState<CardType[]>()
+  const [cards, setCards] = useState<CardType[]>([])
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
+
   const getCards = async () => {
-    const cardsData = await cardsService.getCards(10, columnInfo.id)
-    setCards(cardsData.cards)
+    if (isLoading || !hasMore) return
+    setIsLoading(true)
+
+    try {
+      console.log('[getCards] 호출됨 - page:', page, 'columnId:', columnInfo.id)
+
+      const res = await cardsService.getCards(3, columnInfo.id, page)
+
+      console.log('[getCards] 응답 데이터:', res)
+      console.log('[getCards] 받아온 카드 개수:', res.cards.length)
+      console.log('[getCards] 전체 카드 수 (totalCount):', res.totalCount)
+
+      const prevIds = new Set(cards.map((card) => card.id))
+      const newCards = res.cards.filter((card) => !prevIds.has(card.id))
+
+      // 새로운 카드가 없을 경우에는 더 이상 불러올 카드가 없다고 설정
+      if (newCards.length === 0) {
+        console.log('[getCards] 새로운 카드 없음 - hasMore false 설정')
+        setHasMore(false)
+        return
+      }
+
+      // 받아온 카드를 기존 카드 목록에 추가
+      setCards((prevCards) => {
+        const updatedCards = [...prevCards, ...newCards]
+        console.log('[getCards] 누적된 카드 개수:', updatedCards.length)
+        return updatedCards
+      })
+
+      // cursorId가 없으면 더 이상 불러올 데이터가 없다는 의미
+      if (!res.cursorId) {
+        console.log('[getCards] 모든 카드 로드 완료 - hasMore false 설정')
+        setHasMore(false)
+      }
+
+      setPage((prev) => prev + 1)
+    } catch (e) {
+      console.error('[getCards] 에러 발생:', e)
+    } finally {
+      setIsLoading(false)
+    }
   }
 
+  const loadMoreCards = () => {
+    if (!hasMore || isLoading) {
+      console.log(
+        '[loadMoreCards] 무시됨 - hasMore:',
+        hasMore,
+        'isLoading:',
+        isLoading
+      )
+      return
+    }
+    getCards()
+  }
+
+  // 초기 로딩
   useEffect(() => {
     getCards()
-  }, [refreshTrigger])
+  }, [])
 
   return (
-    <>
-      <div className={styles.column}>
-        {/* 상단: 컬럼 제목 + 카드 개수 + 설정 버튼 */}
-        <div className={styles.header}>
-          <div className={styles.titleWrapper}>
-            <div className={styles.dotTitle}>
-              <div className={styles.dot} />
-              <span className="text-lg-medium">{columnInfo.title}</span>
-            </div>
-            <span className={styles.cardCount}>
-              {/* && 연산자 사용 이유 : getCards는 비동기로 동작, cards가 확정적으로 동작하지 않음. cards가 있을 때만 cards.length가 동작할 수 있게 */}
-              {cards && cards.length}
-            </span>
+    <div className={styles.column}>
+      {/* 상단: 컬럼 제목 + 카드 개수 + 설정 버튼 */}
+      <div className={styles.header}>
+        <div className={styles.titleWrapper}>
+          <div className={styles.dotTitle}>
+            <div className={styles.dot} />
+            <span className="text-lg-medium">{columnInfo.title}</span>
           </div>
-          <button
-            onClick={() => {
-              handleColumnEditModal(true)
-              handleColumnOptionClick(columnInfo)
-            }}
-            className={styles.settingsButton}
-          >
-            <Image
-              src="/assets/icon/settings-logo.svg"
-              alt="설정 아이콘"
-              width={24}
-              height={24}
-            />
-          </button>
+          <span className={styles.cardCount}>{cards && cards.length}</span>
         </div>
-
-        {/* + 버튼 */}
-        <div className={styles.addButtonWrapper}>
-          <ButtonDashboard
-            onClick={() => handleCardCreateModalOpen(columnInfo.id)}
-            color="bg-white"
-            className={styles.addButton}
-            prefix={
-              <div className={styles.addIcon}>
-                <Image
-                  src="/assets/icon/add-box.svg"
-                  alt="카드 추가 버튼"
-                  width={22}
-                  height={22}
-                  unoptimized
-                  style={{
-                    width: '2.2rem',
-                    height: '2.2rem',
-                    display: 'block',
-                  }}
-                />
-              </div>
-            }
+        <button
+          onClick={() => {
+            handleColumnEditModal(true)
+            handleColumnOptionClick(columnInfo)
+          }}
+          className={styles.settingsButton}
+        >
+          <Image
+            src="/assets/icon/settings-logo.svg"
+            alt="설정 아이콘"
+            width={24}
+            height={24}
           />
-        </div>
+        </button>
+      </div>
 
+      {/* + 버튼 */}
+      <div className={styles.addButtonWrapper}>
+        <ButtonDashboard
+          onClick={() => handleCardCreateModalOpen(columnInfo.id)}
+          color="bg-white"
+          className={styles.addButton}
+          prefix={
+            <div className={styles.addIcon}>
+              <Image
+                src="/assets/icon/add-box.svg"
+                alt="카드 추가 버튼"
+                width={22}
+                height={22}
+                unoptimized
+                style={{
+                  width: '2.2rem',
+                  height: '2.2rem',
+                  display: 'block',
+                }}
+              />
+            </div>
+          }
+        />
+      </div>
+
+      <div className={styles.card_list}>
         {/* 카드 리스트 */}
         {cards && (
           <CardTable
@@ -100,9 +153,12 @@ export default function Column({
             dashboardId={dashboardId}
             columnInfo={columnInfo}
             setRefreshTrigger={setRefreshTrigger}
+            onLoadMore={loadMoreCards}
+            isLoading={isLoading}
+            hasMore={hasMore}
           />
         )}
       </div>
-    </>
+    </div>
   )
 }

--- a/src/components/domain/dashboard/column.module.css
+++ b/src/components/domain/dashboard/column.module.css
@@ -81,7 +81,7 @@
   flex-shrink: 0;
 }
 .card_list {
-  max-height: 60vh;
+  max-height: 100rem;
   overflow-y: auto;
   display: flex;
   flex-direction: column;

--- a/src/components/domain/dashboard/column.module.css
+++ b/src/components/domain/dashboard/column.module.css
@@ -80,3 +80,10 @@
   height: 2.2rem;
   flex-shrink: 0;
 }
+.card_list {
+  max-height: 60vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -11,7 +11,7 @@ type UserData = {
 type AuthState = {
   accessToken: string | null
   userData: UserData | null
-  setAuth: (token: string) => void
+  setAccessToken: (token: string) => void
   setUserData: (data: UserData) => void
   clearAuth: () => void
 }
@@ -21,22 +21,17 @@ export const useAuthStore = create<AuthState>()(
     (set) => ({
       accessToken: null,
       userData: null,
-      setAuth: (token) => set({ accessToken: token }),
-      setUserData: (data) => {
-        set({
-          userData: data,
-        })
-      },
-      clearAuth: () =>
-        set({
-          accessToken: null,
-          userData: null,
-        }),
+      setAccessToken: (token: string) => set({ accessToken: token }),
+      setUserData: (data: UserData) => set({ userData: data }),
+      clearAuth: () => set({ accessToken: null, userData: null }), // 인증 정보를 모두 지우는 함수
     }),
     {
       name: 'auth-storage',
-      storage: createJSONStorage(() => localStorage),
+      storage:
+        typeof window !== 'undefined' &&
+        window.location.hostname === 'localhost'
+          ? createJSONStorage(() => localStorage) // 개발환경에서는 로컬스토리지 사용
+          : createJSONStorage(() => sessionStorage), // 배포 환경에서는 세션스토리지 사용
     }
   )
 )
-// 헉 이거 로컬만 있어요. 배포할 때는 세션으로 하는 조건문 없어졌어요.


### PR DESCRIPTION
## 📌 PR 개요

1. 각 컬럼마다 무한스크롤 존재합니다. 초기 5개 불러오고 그 이후로 스크롤이 바닥에 닿을 때마다 추가로 카드를 불러옵니다. 

## 🏃‍♂️‍➡️ 요구사항
- [x] 각 칼럼의 카드들은 무한 스크롤로 이어지도록 하세요.
- [ ]

## 🔥 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 📝 변경 내용

- [ ] 1기능에 대한 구체 내용 기술
- [ ] 2기능에 대한 구체 내용 기술
- [ ] 3기능에 대한 구체 내용 기술

## 📷 스크린샷 (선택)


![초기](https://github.com/user-attachments/assets/58618a38-40e1-4821-89dd-0594a2db19bf)
![각 컬럼마다 ](https://github.com/user-attachments/assets/d9000dc9-7334-445a-b72b-7493c8110bda)



## 🚧 관련 이슈

<!-- 관련 이슈 번호가 있다면 적어주세요 (e.g. #123 또는 ISSUE-123 과 같은 JIRA key) -->

## 💡 추가 정보

+) 반응형 때 테스트도 하고 싶었는데 머지가 안되어있어서 일단 제가 대충 관리자도구 켜서 했는데 잘되는 것 같긴하더라고요,,?
쨋든 다시 확인해 보긴 해야할 것 같습니다